### PR TITLE
Fixes #4

### DIFF
--- a/RxDataSources.podspec
+++ b/RxDataSources.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxDataSources"
-  s.version          = "0.3"
+  s.version          = "0.4"
   s.summary          = "This is a collection of reactive data sources for UITableView and UICollectionView."
   s.description      = <<-DESC
 This is a collection of reactive data sources for UITableView and UICollectionView.
@@ -40,6 +40,6 @@ data
 
   s.source_files          = 'Sources/**/*.swift'
 
-  s.dependency 'RxSwift', '~> 2.0'
-  s.dependency 'RxCocoa', '~> 2.0'
+  s.dependency 'RxSwift', '~> 2.1.0'
+  s.dependency 'RxCocoa', '~> 2.1.0'
 end


### PR DESCRIPTION
Bumps `RxSwift`/`RxCocoa` dependency to `2.1.0` to be able to compile due to a missing `SectionedViewDataSourceType` reference