### PR TITLE
Changed `SectionModelType` to `AnimatableSectionModelType` on `RxTableViewSectionedAnimatedDataSource` and `RxCollectionViewSectionedAnimatedDataSource`

### DIFF
--- a/Sources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -13,10 +13,12 @@ import RxSwift
 import RxCocoa
 #endif
 
-public class RxCollectionViewSectionedAnimatedDataSource<S: SectionModelType>
+public class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
     : CollectionViewSectionedDataSource<S>
     , RxCollectionViewDataSourceType {
     public typealias Element = [Changeset<S>]
+    public typealias ItemType = S.Item.Identity
+
     public var animationConfiguration: AnimationConfiguration? = nil
     
     // For some inexplicable reason, when doing animated updates first time
@@ -41,5 +43,14 @@ public class RxCollectionViewSectionedAnimatedDataSource<S: SectionModelType>
             }
 
         }.on(observedEvent)
+    }
+    
+    override public func modelAtIndexPath(indexPath: NSIndexPath) throws -> Any {
+        let model = itemAtIndexPath(indexPath)
+        if let m = model as? IdentitifiableValue<ItemType> {
+            return m.value
+        } else {
+            return model
+        }
     }
 }

--- a/Sources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -17,8 +17,6 @@ public class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionMod
     : CollectionViewSectionedDataSource<S>
     , RxCollectionViewDataSourceType {
     public typealias Element = [Changeset<S>]
-    public typealias ItemType = S.Item.Identity
-
     public var animationConfiguration: AnimationConfiguration? = nil
     
     // For some inexplicable reason, when doing animated updates first time
@@ -43,14 +41,5 @@ public class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionMod
             }
 
         }.on(observedEvent)
-    }
-    
-    override public func modelAtIndexPath(indexPath: NSIndexPath) throws -> Any {
-        let model = itemAtIndexPath(indexPath)
-        if let m = model as? IdentitifiableValue<ItemType> {
-            return m.value
-        } else {
-            return model
-        }
     }
 }

--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -18,8 +18,6 @@ public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelTyp
     , RxTableViewDataSourceType {
     
     public typealias Element = [Changeset<S>]
-    public typealias ItemType = S.Item.Identity
-
     public var animationConfiguration: AnimationConfiguration? = nil
 
     public override init() {
@@ -38,14 +36,5 @@ public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelTyp
                 }
             }
         }.on(observedEvent)
-    }
-    
-    override public func modelAtIndexPath(indexPath: NSIndexPath) throws -> Any {
-        let model = itemAtIndexPath(indexPath)
-        if let m = model as? IdentitifiableValue<ItemType> {
-            return m.value
-        } else {
-            return model
-        }
     }
 }

--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -13,11 +13,13 @@ import RxSwift
 import RxCocoa
 #endif
 
-public class RxTableViewSectionedAnimatedDataSource<S: SectionModelType>
+public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
     : RxTableViewSectionedDataSource<S>
     , RxTableViewDataSourceType {
     
     public typealias Element = [Changeset<S>]
+    public typealias ItemType = S.Item.Identity
+
     public var animationConfiguration: AnimationConfiguration? = nil
 
     public override init() {
@@ -36,5 +38,14 @@ public class RxTableViewSectionedAnimatedDataSource<S: SectionModelType>
                 }
             }
         }.on(observedEvent)
+    }
+    
+    override public func modelAtIndexPath(indexPath: NSIndexPath) throws -> Any {
+        let model = itemAtIndexPath(indexPath)
+        if let m = model as? IdentitifiableValue<ItemType> {
+            return m.value
+        } else {
+            return model
+        }
     }
 }


### PR DESCRIPTION
Changed `modelAtIndexPath` to return actual model, not wrapped model by `IdentifiableValue` if using AnimatedDataSource, so that we can use `UITableView`'s `rx_modelSelected` with actual ModelType, not `IdentitifiableValue<ModelType>` as a parameter.