### PR TITLE
This is useful when we need to support user dragging and reordering

### DIFF
--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -21,7 +21,7 @@ public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelTyp
     public var animationConfiguration = AnimationConfiguration()
 
     var dataSet = false
-    var suspendOnNextFrame = false
+    public var suspendOnNextFrame = false
 
     public override init() {
         super.init()

--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -21,6 +21,7 @@ public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelTyp
     public var animationConfiguration = AnimationConfiguration()
 
     var dataSet = false
+    var suspendOnNextFrame = false
 
     public override init() {
         super.init()
@@ -28,8 +29,9 @@ public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelTyp
 
     public func tableView(tableView: UITableView, observedEvent: Event<Element>) {
         UIBindingObserver(UIElement: self) { dataSource, newSections in
-            if !self.dataSet {
+            if !self.dataSet || self.suspendOnNextFrame {
                 self.dataSet = true
+                self.suspendOnNextFrame = false
                 dataSource.setSections(newSections)
                 tableView.reloadData()
             }


### PR DESCRIPTION
If it's triggered by user dragging cell from A to B and cause the data to rerender, we don't need the animation to happen again. (Which will be wrong anyway)

Not sure if it make sense. 😄 