### PR TITLE
assure Apple extensions compatibility

### DIFF
--- a/RxDataSources.xcodeproj/project.pbxproj
+++ b/RxDataSources.xcodeproj/project.pbxproj
@@ -1132,6 +1132,7 @@
 		C8984C631C36AF35001E4272 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1154,6 +1155,7 @@
 		C8984C641C36AF35001E4272 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
Removes `linking against a dylib which is not safe for use in application extensions:` warning in clients extensions projects and avoids possibly being rejected on Apple App Store submission.