### PR TITLE
Rename RxTableViewSectionedDataSource in TableViewSectionedDataSource

### DIFF
--- a/Example/Example2_RandomizedSectionsAnimation.swift
+++ b/Example/Example2_RandomizedSectionsAnimation.swift
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
 // MARK: Skinning
 extension ViewController {
 
-    func skinTableViewDataSource(_ dataSource: RxTableViewSectionedDataSource<NumberSection>) {
+    func skinTableViewDataSource(_ dataSource: TableViewSectionedDataSource<NumberSection>) {
         dataSource.configureCell = { (_, tv, ip, i) in
             let cell = tv.dequeueReusableCell(withIdentifier: "Cell") ?? UITableViewCell(style:.default, reuseIdentifier: "Cell")
 

--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -14,7 +14,7 @@ import RxCocoa
 #endif
 
 public class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
-    : RxTableViewSectionedDataSource<S>
+    : TableViewSectionedDataSource<S>
     , RxTableViewDataSourceType {
     
     public typealias Element = [S]

--- a/Sources/DataSources+Rx/RxTableViewSectionedReloadDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedReloadDataSource.swift
@@ -14,7 +14,7 @@ import RxCocoa
 #endif
 
 public class RxTableViewSectionedReloadDataSource<S: SectionModelType>
-    : RxTableViewSectionedDataSource<S>
+    : TableViewSectionedDataSource<S>
     , RxTableViewDataSourceType {
     public typealias Element = [S]
 

--- a/Sources/DataSources/TableViewSectionedDataSource.swift
+++ b/Sources/DataSources/TableViewSectionedDataSource.swift
@@ -100,13 +100,13 @@ public class _TableViewSectionedDataSource
 
 }
 
-public class RxTableViewSectionedDataSource<S: SectionModelType>
+public class TableViewSectionedDataSource<S: SectionModelType>
     : _TableViewSectionedDataSource
     , SectionedViewDataSourceType {
     
     public typealias I = S.Item
     public typealias Section = S
-    public typealias CellFactory = (RxTableViewSectionedDataSource<S>, UITableView, IndexPath, I) -> UITableViewCell
+    public typealias CellFactory = (TableViewSectionedDataSource<S>, UITableView, IndexPath, I) -> UITableViewCell
 
     #if DEBUG
     // If data source has already been bound, then mutating it
@@ -166,14 +166,14 @@ public class RxTableViewSectionedDataSource<S: SectionModelType>
         }
     }
     
-    public var titleForHeaderInSection: ((RxTableViewSectionedDataSource<S>, Int) -> String?)? {
+    public var titleForHeaderInSection: ((TableViewSectionedDataSource<S>, Int) -> String?)? {
         didSet {
             #if DEBUG
                 ensureNotMutatedAfterBinding()
             #endif
         }
     }
-    public var titleForFooterInSection: ((RxTableViewSectionedDataSource<S>, Int) -> String?)? {
+    public var titleForFooterInSection: ((TableViewSectionedDataSource<S>, Int) -> String?)? {
         didSet {
             #if DEBUG
                 ensureNotMutatedAfterBinding()
@@ -181,14 +181,14 @@ public class RxTableViewSectionedDataSource<S: SectionModelType>
         }
     }
     
-    public var canEditRowAtIndexPath: ((RxTableViewSectionedDataSource<S>, IndexPath) -> Bool)? {
+    public var canEditRowAtIndexPath: ((TableViewSectionedDataSource<S>, IndexPath) -> Bool)? {
         didSet {
             #if DEBUG
                 ensureNotMutatedAfterBinding()
             #endif
         }
     }
-    public var canMoveRowAtIndexPath: ((RxTableViewSectionedDataSource<S>, IndexPath) -> Bool)? {
+    public var canMoveRowAtIndexPath: ((TableViewSectionedDataSource<S>, IndexPath) -> Bool)? {
         didSet {
             #if DEBUG
                 ensureNotMutatedAfterBinding()
@@ -199,14 +199,14 @@ public class RxTableViewSectionedDataSource<S: SectionModelType>
     public var rowAnimation: UITableViewRowAnimation = .automatic
 
     #if os(iOS)
-    public var sectionIndexTitles: ((RxTableViewSectionedDataSource<S>) -> [String]?)? {
+    public var sectionIndexTitles: ((TableViewSectionedDataSource<S>) -> [String]?)? {
         didSet {
             #if DEBUG
             ensureNotMutatedAfterBinding()
             #endif
         }
     }
-    public var sectionForSectionIndexTitle:((RxTableViewSectionedDataSource<S>, _ title: String, _ index: Int) -> Int)? {
+    public var sectionForSectionIndexTitle:((TableViewSectionedDataSource<S>, _ title: String, _ index: Int) -> Int)? {
         didSet {
             #if DEBUG
             ensureNotMutatedAfterBinding()


### PR DESCRIPTION
## Summary
Renamed `RxTableViewSectionedDataSource` in `TableViewSectionedDataSource` to be consistent with `CollectionViewSectionedDataSource`.