### PR TITLE
Update CFBundleShortVersionString to current release version number

### DIFF
--- a/RxDataSources/Info.plist
+++ b/RxDataSources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0.beta.1</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Hi @kzaher 

CFBundleShortVersionString was not in line with the release version, this is an issue if you try to submit the app and are using carthage as a dependency manager.
 