### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Observable.just(sections)
 ### Animations
 To implement animations with RxDataSources, the same steps are required as with non-animated data, execept:
 - SectionOfCustomData needs to conform to `AnimatableSectionModelType`
-- dataSource needs to be an instance of `RxTableViewSectionedAnimatedDataSource` or `RxTableViewSectionedAnimatedDataSource`
+- dataSource needs to be an instance of `RxTableViewSectionedAnimatedDataSource` or `RxCollectionViewSectionedAnimatedDataSource`
 
 
 ## Requirements


### PR DESCRIPTION
`RxTableViewSectionedAnimatedDataSource` is written twice. 
If you don't mean this, This isn't a necessary part :]