### PR TITLE
Check the section index on tableView:numberOfRowsInSection: call

### DIFF
--- a/Sources/DataSources/TableViewSectionedDataSource.swift
+++ b/Sources/DataSources/TableViewSectionedDataSource.swift
@@ -233,7 +233,7 @@ open class TableViewSectionedDataSource<S: SectionModelType>
     }
     
     open override func _rx_tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return _sectionModels[section].items.count
+        return _sectionModels.indices.contains(section) ? _sectionModels[section].items.count : 0
     }
     
     open override func _rx_tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
The `tableView:numberOfRowsInSection:` method might be called before the `numberOfSections`. Thus we should validate the section index to prevent the `Index out of range` error. 


Here is the example that causes a crash:
```
struct SectionOfCustomData {
    var items: [Item]
}
extension SectionOfCustomData: SectionModelType {
    typealias Item = String
    
    init(original: SectionOfCustomData, items: [Item]) {
        self = original
        self.items = items
    }
}

class RxTableViewController: UIViewController {
    
    var tableView: UITableView!
    let disposeBag = DisposeBag()
    
    let dataSource = RxTableViewSectionedReloadDataSource<SectionOfCustomData>()
    
    override func viewDidLoad() {
        super.viewDidLoad()
        
        self.tableView = UITableView(frame: self.view.bounds, style: .plain)
        self.view.addSubview(self.tableView)

        self.tableView.tableFooterView = UIView()
        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
        self.tableView.rowHeight = UITableViewAutomaticDimension
        self.tableView.estimatedRowHeight = 100

        Observable.just([SectionOfCustomData]()).asDriver(onErrorJustReturn: []).drive(tableView.rx.items(dataSource: self.dataSource))
            .addDisposableTo(disposeBag)
    }
}
```