### PR TITLE
Added types on the configure cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let dataSource = RxTableViewSectionedReloadDataSource<SectionOfCustomData>()
 - etc
 
 ```swift 
-dataSource.configureCell = { ds, tv, ip, item in
+dataSource.configureCell = { (ds: RxTableViewSectionedReloadDataSource<SectionOfCustomData>, tv: UITableView, ip: IndexPath, item: Item) in
   let cell = tv.dequeueReusableCell(withIdentifier: "Cell", for: ip)
   cell.textLabel?.text = "Item \(item.anInt): \(item.aString) - \(item.aCGPoint.x):\(item.aCGPoint.y)"
   return cell


### PR DESCRIPTION
This is the first part where the data sources are overridden. I think for people learning how to use RxDataSources, specifying the types here would be important.

I understand if you think brevity would be more important; my point is that it might not be that clear for inexperienced users.