### PR TITLE
Adding a reasonable default for sectionForSectionIndexTitle

### DIFF
--- a/Sources/DataSources/TableViewSectionedDataSource.swift
+++ b/Sources/DataSources/TableViewSectionedDataSource.swift
@@ -83,7 +83,7 @@ open class _TableViewSectionedDataSource
     }
 
     open func _rx_tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
-        return 0
+        return index
     }
 
     open func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {


### PR DESCRIPTION
Fixes #105 by adding a reasonable default for sectionForSectionIndexTitle so tapping the index navigates to the correct section.