### PR TITLE
fix tableView batch update animation

### DIFF
--- a/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/DataSources+Rx/RxTableViewSectionedAnimatedDataSource.swift
@@ -48,11 +48,13 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
                     do {
                         let differences = try differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
 
+                        tableView.beginUpdates()
                         for difference in differences {
                             dataSource.setSections(difference.finalSections)
 
                             tableView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
                         }
+                        tableView.endUpdates()
                     }
                     catch let e {
                         rxDebugFatalError(e)

--- a/Sources/DataSources/UI+SectionedViewType.swift
+++ b/Sources/DataSources/UI+SectionedViewType.swift
@@ -52,9 +52,7 @@ extension UITableView : SectionedViewType {
     }
 
   public func performBatchUpdates<S: SectionModelType>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
-        self.beginUpdates()
         _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
-        self.endUpdates()
     }
 }
 


### PR DESCRIPTION
Current code repeats begin/endUpdates for every batch changes so the final animation isn't smooth enough. This PR is fixing this behaviour by establishing begin/endUpdates for all batches at once.