### PR TITLE
Fixed crash for using estimatedHeightForRow and dataSource

### DIFF
--- a/Sources/DataSources/TableViewSectionedDataSource.swift
+++ b/Sources/DataSources/TableViewSectionedDataSource.swift
@@ -233,6 +233,7 @@ open class TableViewSectionedDataSource<S: SectionModelType>
     }
     
     open override func _rx_tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard _sectionModels.count > section else { return 0 }
         return _sectionModels[section].items.count
     }
     


### PR DESCRIPTION
Hi!

I noticed a bug related to UIKit which caused a crash once you're trying to bind dataSource before it's being set and you're using `estimatedHeightForRow` property or a method of a delegate.

This solution is to check if `count` of `sectionModels` is bigger than `section`.

Using `estimatedHightForRow` caused calling `numberOfRowsInSection` before `numberOfSection`, the result of it is crash of app if your sectionModel is empty. 