### PR TITLE
Fix Swift Package Manager build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - BUILD="pod repo update && pod lib lint RxDataSources.podspec --verbose && pod lib lint Differentiator.podspec --verbose "
   - BUILD="carthage update --platform iOS  && carthage build --no-skip-current --platform iOS"
   - BUILD="carthage update --platform tvOS && carthage build --no-skip-current --platform tvOS"
+  - BUILD="swift test"
 
 script: eval "${BUILD}"
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,10 @@ let package = Package(
     .library(name: "Differentiator", targets: ["Differentiator"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", "4.0.0" ..< "5.0.0"),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
   ],
   targets: [
-    .target(name: "RxDataSources", dependencies: ["Differentiator"]),
+    .target(name: "RxDataSources", dependencies: ["Differentiator", "RxSwift", "RxCocoa"]),
     .target(name: "Differentiator"),
     .testTarget(name: "RxDataSourcesTests", dependencies: ["RxDataSources"]),
   ]

--- a/Sources/RxDataSources/Deprecated.swift
+++ b/Sources/RxDataSources/Deprecated.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 kzaher. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
 extension CollectionViewSectionedDataSource {
     @available(*, deprecated, renamed: "configureSupplementaryView")
     public var supplementaryViewFactory: ConfigureSupplementaryView {
@@ -17,3 +18,4 @@ extension CollectionViewSectionedDataSource {
         }
     }
 }
+#endif


### PR DESCRIPTION
This will fix Swift Package Manager build:

* Add RxSwift and RxCocoa dependency to RxDataSources target
* Add OS checking if-statement in Deprecated.swift
