### PR TITLE
Removing unused AnimationConfiguration from RxCollectionViewSectionedAnimatedDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-#### Master
+#### Breaking Changes
+* Removing unused AnimationConfiguration from RxCollectionViewSectionedAnimatedDataSource, making AnimationConfiguration generic so it is more flexible for future usage.
 
+#### Master
 * Added support of mutable CellViewModels.
 
 ## [4.0.1](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/4.0.1)

--- a/Sources/RxDataSources/AnimationConfiguration.swift
+++ b/Sources/RxDataSources/AnimationConfiguration.swift
@@ -10,17 +10,22 @@
     import Foundation
     import UIKit
 
+    public typealias TableViewAnimationConfiguration = AnimationConfiguration<UITableView.Animation>
+    
     /**
      Exposes custom animation styles for insertion, deletion and reloading behavior.
      */
-    public struct AnimationConfiguration {
-        public let insertAnimation: UITableView.RowAnimation
-        public let reloadAnimation: UITableView.RowAnimation
-        public let deleteAnimation: UITableView.RowAnimation
-
-        public init(insertAnimation: UITableView.RowAnimation = .automatic,
-                    reloadAnimation: UITableView.RowAnimation = .automatic,
-                    deleteAnimation: UITableView.RowAnimation = .automatic) {
+    public struct AnimationConfiguration<Animation> {
+        public let insertAnimation: Animation
+        public let reloadAnimation: Animation
+        public let deleteAnimation: Animation
+    }
+    
+    public extension AnimationConfiguration where Animation == UITableView.Animation {
+        
+        init(insertAnimation: Animation = .automatic,
+             reloadAnimation: Animation = .automatic,
+             deleteAnimation: Animation = .automatic) {
             self.insertAnimation = insertAnimation
             self.reloadAnimation = reloadAnimation
             self.deleteAnimation = deleteAnimation

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -21,21 +21,16 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
     public typealias Element = [Section]
     public typealias DecideViewTransition = (CollectionViewSectionedDataSource<Section>, UICollectionView, [Changeset<Section>]) -> ViewTransition
 
-    // animation configuration
-    public var animationConfiguration: AnimationConfiguration
-
     /// Calculates view transition depending on type of changes
     public var decideViewTransition: DecideViewTransition
 
     public init(
-        animationConfiguration: AnimationConfiguration = AnimationConfiguration(),
         decideViewTransition: @escaping DecideViewTransition = { _, _, _ in .animated },
         configureCell: @escaping ConfigureCell,
         configureSupplementaryView: ConfigureSupplementaryView? = nil,
         moveItem: @escaping MoveItem = { _, _, _ in () },
         canMoveItemAtIndexPath: @escaping CanMoveItemAtIndexPath = { _, _ in false }
         ) {
-        self.animationConfiguration = animationConfiguration
         self.decideViewTransition = decideViewTransition
         super.init(
             configureCell: configureCell,
@@ -78,7 +73,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
                             let updateBlock = {
                                 // sections must be set within updateBlock in 'performBatchUpdates'
                                 dataSource.setSections(difference.finalSections)
-                                collectionView.batchUpdates(difference, animationConfiguration: dataSource.animationConfiguration)
+                                collectionView.batchUpdates(difference)
                             }
                             collectionView.performBatchUpdates(updateBlock, completion: nil)
                         }

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -22,14 +22,14 @@ open class RxTableViewSectionedAnimatedDataSource<Section: AnimatableSectionMode
     public typealias DecideViewTransition = (TableViewSectionedDataSource<Section>, UITableView, [Changeset<Section>]) -> ViewTransition
 
     /// Animation configuration for data source
-    public var animationConfiguration: AnimationConfiguration
+    public var animationConfiguration: TableViewAnimationConfiguration
 
     /// Calculates view transition depending on type of changes
     public var decideViewTransition: DecideViewTransition
 
     #if os(iOS)
         public init(
-                animationConfiguration: AnimationConfiguration = AnimationConfiguration(),
+                animationConfiguration: TableViewAnimationConfiguration = TableViewAnimationConfiguration(),
                 decideViewTransition: @escaping DecideViewTransition = { _, _, _ in .animated },
                 configureCell: @escaping ConfigureCell,
                 titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
@@ -53,7 +53,7 @@ open class RxTableViewSectionedAnimatedDataSource<Section: AnimatableSectionMode
         }
     #else
         public init(
-                animationConfiguration: AnimationConfiguration = AnimationConfiguration(),
+                animationConfiguration: TableViewAnimationConfiguration = TableViewAnimationConfiguration(),
                 decideViewTransition: @escaping DecideViewTransition = { _, _, _ in .animated },
                 configureCell: @escaping ConfigureCell,
                 titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -19,47 +19,49 @@ func indexSet(_ values: [Int]) -> IndexSet {
     return indexSet as IndexSet
 }
 
-extension UITableView : SectionedViewType {
+extension UITableView : AnimatedSectionedViewType {
   
-    public func insertItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
-        self.insertRows(at: paths, with: animationStyle)
+    public typealias Animation = UITableView.RowAnimation
+    
+    public func insertItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation) {
+        self.insertRows(at: paths, with: animation)
     }
     
-    public func deleteItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
-        self.deleteRows(at: paths, with: animationStyle)
+    public func deleteItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation) {
+        self.deleteRows(at: paths, with: animation)
     }
     
     public func moveItemAtIndexPath(_ from: IndexPath, to: IndexPath) {
         self.moveRow(at: from, to: to)
     }
     
-    public func reloadItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
-        self.reloadRows(at: paths, with: animationStyle)
+    public func reloadItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation) {
+        self.reloadRows(at: paths, with: animation)
     }
     
-    public func insertSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
-        self.insertSections(indexSet(sections), with: animationStyle)
+    public func insertSections(_ sections: [Int], animation: Animation) {
+        self.insertSections(indexSet(sections), with: animation)
     }
     
-    public func deleteSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
-        self.deleteSections(indexSet(sections), with: animationStyle)
+    public func deleteSections(_ sections: [Int], animation: Animation) {
+        self.deleteSections(indexSet(sections), with: animation)
     }
     
     public func moveSection(_ from: Int, to: Int) {
         self.moveSection(from, toSection: to)
     }
     
-    public func reloadSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
-        self.reloadSections(indexSet(sections), with: animationStyle)
+    public func reloadSections(_ sections: [Int], animation: Animation) {
+        self.reloadSections(indexSet(sections), with: animation)
     }
 }
 
 extension UICollectionView : SectionedViewType {
-    public func insertItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
+    public func insertItemsAtIndexPaths(_ paths: [IndexPath]) {
         self.insertItems(at: paths)
     }
     
-    public func deleteItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
+    public func deleteItemsAtIndexPaths(_ paths: [IndexPath]) {
         self.deleteItems(at: paths)
     }
 
@@ -67,15 +69,15 @@ extension UICollectionView : SectionedViewType {
         self.moveItem(at: from, to: to)
     }
     
-    public func reloadItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation) {
+    public func reloadItemsAtIndexPaths(_ paths: [IndexPath]) {
         self.reloadItems(at: paths)
     }
     
-    public func insertSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
+    public func insertSections(_ sections: [Int]) {
         self.insertSections(indexSet(sections))
     }
     
-    public func deleteSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
+    public func deleteSections(_ sections: [Int]) {
         self.deleteSections(indexSet(sections))
     }
     
@@ -83,54 +85,101 @@ extension UICollectionView : SectionedViewType {
         self.moveSection(from, toSection: to)
     }
     
-    public func reloadSections(_ sections: [Int], animationStyle: UITableView.RowAnimation) {
+    public func reloadSections(_ sections: [Int]) {
         self.reloadSections(indexSet(sections))
     }
 }
 
 public protocol SectionedViewType {
-    func insertItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation)
-    func deleteItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation)
+    func insertItemsAtIndexPaths(_ paths: [IndexPath])
+    func deleteItemsAtIndexPaths(_ paths: [IndexPath])
     func moveItemAtIndexPath(_ from: IndexPath, to: IndexPath)
-    func reloadItemsAtIndexPaths(_ paths: [IndexPath], animationStyle: UITableView.RowAnimation)
+    func reloadItemsAtIndexPaths(_ paths: [IndexPath])
     
-    func insertSections(_ sections: [Int], animationStyle: UITableView.RowAnimation)
-    func deleteSections(_ sections: [Int], animationStyle: UITableView.RowAnimation)
+    func insertSections(_ sections: [Int])
+    func deleteSections(_ sections: [Int])
     func moveSection(_ from: Int, to: Int)
-    func reloadSections(_ sections: [Int], animationStyle: UITableView.RowAnimation)
+    func reloadSections(_ sections: [Int])
+}
+    
+public protocol AnimatedSectionedViewType {
+    
+    associatedtype Animation
+    
+    func insertItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation)
+    func deleteItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation)
+    func moveItemAtIndexPath(_ from: IndexPath, to: IndexPath)
+    func reloadItemsAtIndexPaths(_ paths: [IndexPath], animation: Animation)
+    
+    func insertSections(_ sections: [Int], animation: Animation)
+    func deleteSections(_ sections: [Int], animation: Animation)
+    func moveSection(_ from: Int, to: Int)
+    func reloadSections(_ sections: [Int], animation: Animation)
 }
 
 extension SectionedViewType {
-    public func batchUpdates<Section>(_ changes: Changeset<Section>, animationConfiguration: AnimationConfiguration) {
-        // swiftlint:disable:next nesting
-        typealias Item = Section.Item
-        
-        deleteSections(changes.deletedSections, animationStyle: animationConfiguration.deleteAnimation)
-        
-        insertSections(changes.insertedSections, animationStyle: animationConfiguration.insertAnimation)
-        for (from, to) in changes.movedSections {
-            moveSection(from, to: to)
-        }
-        
-        deleteItemsAtIndexPaths(
-            changes.deletedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) },
-            animationStyle: animationConfiguration.deleteAnimation
-        )
-        insertItemsAtIndexPaths(
-            changes.insertedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) },
-            animationStyle: animationConfiguration.insertAnimation
-        )
-        reloadItemsAtIndexPaths(
-            changes.updatedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) },
-            animationStyle: animationConfiguration.reloadAnimation
-        )
-        
-        for (from, to) in changes.movedItems {
-            moveItemAtIndexPath(
-                IndexPath(item: from.itemIndex, section: from.sectionIndex),
-                to: IndexPath(item: to.itemIndex, section: to.sectionIndex)
-            )
-        }
+
+    public func batchUpdates<Section>(_ changes: Changeset<Section>) {
+        _batchUpdates(changes: changes, deleteSections: { deletedSections in
+            self.deleteSections(deletedSections)
+        }, insertSections: { insertedSections in
+            self.insertSections(insertedSections)
+        }, moveSection: { from, to in
+            self.moveSection(from, to: to)
+        }, deleteItems: { deletedItems in
+            self.deleteItemsAtIndexPaths(deletedItems)
+        }, insertItems: { insertedItems in
+            self.insertItemsAtIndexPaths(insertedItems)
+        }, updateItems: { updatedItems in
+            self.reloadItemsAtIndexPaths(updatedItems)
+        }, moveItem: { from, to in
+            self.moveItemAtIndexPath(from, to: to)
+        })
+    }
+}
+
+extension AnimatedSectionedViewType {
+
+    public func batchUpdates<Section>(_ changes: Changeset<Section>, animationConfiguration: AnimationConfiguration<Animation>) {
+        _batchUpdates(changes: changes, deleteSections: { deletedSections in
+            self.deleteSections(deletedSections, animation: animationConfiguration.deleteAnimation)
+        }, insertSections: { insertedSections in
+            self.insertSections(insertedSections, animation: animationConfiguration.insertAnimation)
+        }, moveSection: { from, to in
+            self.moveSection(from, to: to)
+        }, deleteItems: { deletedItems in
+            self.deleteItemsAtIndexPaths(deletedItems, animation: animationConfiguration.deleteAnimation)
+        }, insertItems: { insertedItems in
+            self.insertItemsAtIndexPaths(insertedItems, animation: animationConfiguration.insertAnimation)
+        }, updateItems: { updatedItems in
+            self.reloadItemsAtIndexPaths(updatedItems, animation: animationConfiguration.reloadAnimation)
+        }, moveItem: { from, to in
+            self.moveItemAtIndexPath(from, to: to)
+        })
+    }
+}
+
+private typealias SectionChanges = ([Int]) -> Void
+private typealias ItemChanges = ([IndexPath]) -> Void
+
+private func _batchUpdates<S>(
+    changes: Changeset<S>,
+    deleteSections: SectionChanges, insertSections: SectionChanges, moveSection:(Int, Int) -> Void,
+    deleteItems: ItemChanges, insertItems: ItemChanges, updateItems: ItemChanges, moveItem: (IndexPath, IndexPath) -> Void
+) {
+    deleteSections(changes.deletedSections)
+    
+    insertSections(changes.insertedSections)
+    for (from, to) in changes.movedSections {
+        moveSection(from, to)
+    }
+    
+    deleteItems(changes.deletedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) })
+    insertItems(changes.insertedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) })
+    updateItems(changes.updatedItems.map { IndexPath(item: $0.itemIndex, section: $0.sectionIndex) })
+    
+    for (from, to) in changes.movedItems {
+        moveItem(IndexPath(item: from.itemIndex, section: from.sectionIndex), IndexPath(item: to.itemIndex, section: to.sectionIndex))
     }
 }
 #endif


### PR DESCRIPTION
Hi,

I would like to introduce these changes:

- removing unused AnimationConfiguration from RxCollectionViewSectionedAnimatedDataSource 
- making AnimationConfiguration generic so it is more flexible for possible future usage

The reason is that you can't adjust animations of collection view updates in other way than a custom collection view layout. This is why AnimationConfiguration is not used in collection view batch updates (UI+SectionedViewType) and it does not make a sense for a RxCollectionViewSectionedAnimatedDataSource to have such a property. It is just misleading that you could somehow configure different animations for deleting, inserting or reloading items in a collection view.
Moreover, AnimationConfiguration is using UITableViewRowAnimation enum for configuring animation style so why bother with it while using a collection view?
That's why I would like to make it more explicit and not pollute RxCollectionViewSectionedAnimatedDataSource with properties and types it does not use.

Additionally, making AnimationConfiguration generic is more flexible (it is not coupled with UITableViewRowAnimation), hence maybe in the future there will be a specialized collection view data source using a concrete custom collection view layout with a set of predefined animations to use (not constrained to UITableViewRowAnimation enum cases). This also opens a way for the library users to provide their own custom implementations and start using RxDataSources with configurable animations for a collection view (of course conformance of UICollectionView to AnimatedSectionedViewType is needed, but this depends on using a particular collection view layout, so I am not adding it here).