### PR TITLE
Adds a completion block for animated updates

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dhj-Tp-dZp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="dhj-Tp-dZp">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -27,7 +27,7 @@
                                         <rect key="frame" x="0.0" y="35" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DCT-de-sAU" id="AQS-oS-U5w">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Customization using table view delegate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Sgj-7Q-MpH">
@@ -47,7 +47,7 @@
                                         <rect key="frame" x="0.0" y="79" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="04o-Ht-qxL" id="rCL-pV-Obt">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Randomize Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="lN3-iK-CfR">
@@ -67,7 +67,7 @@
                                         <rect key="frame" x="0.0" y="123" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vNm-h9-1nj" id="3KB-x6-Bl9">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Editing Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="cL7-ld-vsF">
@@ -87,7 +87,7 @@
                                         <rect key="frame" x="0.0" y="167" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Fqd-tI-okg" id="JbD-At-21t">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Multiple section models Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Naj-Gs-fPx">
@@ -107,7 +107,7 @@
                                         <rect key="frame" x="0.0" y="211" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="enJ-vd-aIt" id="CuQ-R1-3J9">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="UIPicker example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8u1-T3-xJl">
@@ -121,6 +121,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="uAN-F4-VDT" kind="show" id="xi9-vR-Y5w"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="xFH-hh-Bw7" style="IBUITableViewCellStyleDefault" id="LKe-Lf-x4P">
+                                        <rect key="frame" x="0.0" y="255" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LKe-Lf-x4P" id="oqY-Xu-XeK">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Animated scroll to item example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xFH-hh-Bw7">
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Ga2-ar-xPg" kind="show" id="cdF-za-ROr"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -273,13 +293,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jm5-Tb-QiA">
-                                                    <rect key="frame" x="18" y="8" width="57.5" height="57.5"/>
+                                                    <rect key="frame" x="25" y="11" width="52" height="52"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="jm5-Tb-QiA" secondAttribute="height" multiplier="1:1" id="0w2-Je-zOU"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xUN-kP-UJi">
-                                                    <rect key="frame" x="83" y="26.5" width="42" height="20.5"/>
+                                                    <rect key="frame" x="84.5" y="27" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -306,10 +326,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zqc-fI-U05">
-                                                    <rect key="frame" x="307" y="17.5" width="51" height="31"/>
+                                                    <rect key="frame" x="300" y="17.5" width="51" height="31"/>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="84f-ua-HYC">
-                                                    <rect key="frame" x="20" y="22.5" width="42" height="20.5"/>
+                                                    <rect key="frame" x="27" y="22.5" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -335,10 +355,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="bIg-eH-oOg">
-                                                    <rect key="frame" x="273" y="19.5" width="94" height="29"/>
+                                                    <rect key="frame" x="266" y="19.5" width="94" height="29"/>
                                                 </stepper>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vs1-3m-THl">
-                                                    <rect key="frame" x="20" y="23.5" width="42" height="20.5"/>
+                                                    <rect key="frame" x="27" y="23.5" width="42" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -375,6 +395,49 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NoZ-ZR-xZg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1171" y="1695"/>
+        </scene>
+        <!--Animated Scroll To Item Example-->
+        <scene sceneID="8fS-fY-QdY">
+            <objects>
+                <viewController id="Ga2-ar-xPg" customClass="AnimatedScrollToItemExample" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="xJ3-0a-RwL"/>
+                        <viewControllerLayoutGuide type="bottom" id="UJY-sp-BAt"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="bIE-Rs-Azw">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="w1m-y1-NJ0">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="UITableViewCell" id="Y4j-6a-Vyf">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Y4j-6a-Vyf" id="0L5-Ft-Ozp" customClass="UITableViewCell">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="w1m-y1-NJ0" secondAttribute="trailing" id="DCM-Sg-HYB"/>
+                            <constraint firstItem="UJY-sp-BAt" firstAttribute="top" secondItem="w1m-y1-NJ0" secondAttribute="bottom" id="KHL-D2-SrC"/>
+                            <constraint firstItem="w1m-y1-NJ0" firstAttribute="top" secondItem="xJ3-0a-RwL" secondAttribute="bottom" id="Ryf-H8-A5u"/>
+                            <constraint firstItem="w1m-y1-NJ0" firstAttribute="leading" secondItem="bIE-Rs-Azw" secondAttribute="leading" id="ib3-7g-EC5"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="w1m-y1-NJ0" id="7iA-0o-pxW"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jjk-3N-fFB" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="308" y="1692.5037481259371"/>
         </scene>
         <!--Partial Updates View Controller-->
         <scene sceneID="2Ak-6r-Q44">

--- a/Example/Example6_AnimatedScrollToItem.swift
+++ b/Example/Example6_AnimatedScrollToItem.swift
@@ -1,0 +1,86 @@
+//
+//  Example6_AnimatedScrollToItem.swift
+//  RxDataSources
+//
+//  Created by Jakub Turek on 17/11/2017.
+//  Copyright © 2017 kzaher. All rights reserved.
+//
+
+import RxCocoa
+import RxDataSources
+import RxSwift
+import UIKit
+
+struct DummySection {
+    var title: String
+    var items: [DummyItem]
+}
+
+extension DummySection: AnimatableSectionModelType {
+    init(original: DummySection, items: [DummyItem]) {
+        self = original
+        self.items = items
+    }
+
+    var identity: String {
+        return title
+    }
+}
+
+struct DummyItem: IdentifiableType, Equatable {
+    var identity: Int
+
+    static func == (lhs: DummyItem, rhs: DummyItem) -> Bool {
+        return lhs.identity == rhs.identity
+    }
+}
+
+final class AnimatedScrollToItemExample: UIViewController {
+
+    let sections: Variable<[DummySection]> = Variable([])
+    let disposeBag: DisposeBag = DisposeBag()
+
+    @IBOutlet weak var tableView: UITableView!
+
+    override func viewDidLoad() {
+        Observable<Int>.timer(0.0, period: 3.0, scheduler: ConcurrentMainScheduler.instance)
+            .map { _ in (Int(arc4random()) + 50) % 200 }
+            .map { sectionCount -> [DummySection] in
+                (0..<sectionCount).map { sectionIndex in
+                    let item = DummyItem(identity: Int(sectionIndex))
+                    return DummySection(title: "Section \(sectionIndex)", items: [item])
+                }
+            }
+            .bind(to: sections)
+            .disposed(by: disposeBag)
+
+        let dataSource = RxTableViewSectionedAnimatedDataSource<DummySection>(
+            configureCell: { (_, tableView, indexPath, item: DummyItem) in
+                let cell: UITableViewCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+                cell.textLabel?.text = "I am entry in section \(item.identity)"
+
+                return cell
+            },
+            titleForHeaderInSection: { dataSource, section in
+                return dataSource.sectionModels[section].title
+            }
+        )
+
+        dataSource.updatesCompleted
+            .map { [unowned self] _ in
+                self.tableView.numberOfSections
+            }
+            .subscribe(onNext: { [unowned self] sections in
+                let randomSection = Int(arc4random()) % sections
+                print("Scrolling to section: \(randomSection)")
+                self.tableView.scrollToRow(at: IndexPath(row: 0, section: randomSection), at: .top, animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        sections.asObservable()
+            .observeOn(MainScheduler.instance)
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+    }
+
+}

--- a/RxDataSources.xcodeproj/project.pbxproj
+++ b/RxDataSources.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		845F61FB1CCFDED600A8BE32 /* TitleSteperTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F61FA1CCFDED600A8BE32 /* TitleSteperTableViewCell.swift */; };
 		845F61FD1CCFF63600A8BE32 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845F61FC1CCFF63600A8BE32 /* UIKitExtensions.swift */; };
 		84FC6BEE1CA4830A00D3C605 /* Example3_TableViewEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC6BED1CA4830A00D3C605 /* Example3_TableViewEditing.swift */; };
+		8C945B601FBEF763006B4DFF /* Example6_AnimatedScrollToItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C945B4C1FBEF762006B4DFF /* Example6_AnimatedScrollToItem.swift */; };
 		9FF3014E1C4AA6DA007376BD /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FF3014C1C4AA6DA007376BD /* RxCocoa.framework */; };
 		9FF301501C4AA6DA007376BD /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FF3014D1C4AA6DA007376BD /* RxSwift.framework */; };
 		A5E035641F0BD55A00EA6BDE /* Example5_UIPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E035631F0BD55A00EA6BDE /* Example5_UIPickerView.swift */; };
@@ -338,6 +339,7 @@
 		845F61FA1CCFDED600A8BE32 /* TitleSteperTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleSteperTableViewCell.swift; sourceTree = "<group>"; };
 		845F61FC1CCFF63600A8BE32 /* UIKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		84FC6BED1CA4830A00D3C605 /* Example3_TableViewEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Example3_TableViewEditing.swift; sourceTree = "<group>"; };
+		8C945B4C1FBEF762006B4DFF /* Example6_AnimatedScrollToItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Example6_AnimatedScrollToItem.swift; sourceTree = "<group>"; };
 		9FF301481C4AA6D1007376BD /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/tvOS/RxCocoa.framework; sourceTree = "<group>"; };
 		9FF301491C4AA6D1007376BD /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/tvOS/RxSwift.framework; sourceTree = "<group>"; };
 		9FF3014C1C4AA6DA007376BD /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
@@ -632,6 +634,7 @@
 				84FC6BED1CA4830A00D3C605 /* Example3_TableViewEditing.swift */,
 				845F61F31CCFD96800A8BE32 /* Example4_DifferentSectionAndItemTypes.swift */,
 				A5E035631F0BD55A00EA6BDE /* Example5_UIPickerView.swift */,
+				8C945B4C1FBEF762006B4DFF /* Example6_AnimatedScrollToItem.swift */,
 				C87DF3421D0219A7006308C5 /* Support */,
 				845F61F51CCFDD7100A8BE32 /* Views */,
 				C8984CA11C36B6FA001E4272 /* Main.storyboard */,
@@ -1160,6 +1163,7 @@
 				84FC6BEE1CA4830A00D3C605 /* Example3_TableViewEditing.swift in Sources */,
 				C8984CA01C36B6FA001E4272 /* Example2_RandomizedSectionsAnimation.swift in Sources */,
 				C87DF3461D0219A7006308C5 /* AppDelegate.swift in Sources */,
+				8C945B601FBEF763006B4DFF /* Example6_AnimatedScrollToItem.swift in Sources */,
 				845F61F41CCFD96800A8BE32 /* Example4_DifferentSectionAndItemTypes.swift in Sources */,
 				845F61FB1CCFDED600A8BE32 /* TitleSteperTableViewCell.swift in Sources */,
 				845F61F91CCFDEA800A8BE32 /* TitleSwitchTableViewCell.swift in Sources */,

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -53,10 +53,15 @@ extension UITableView : SectionedViewType {
         self.reloadSections(indexSet(sections), with: animationStyle)
     }
 
-  public func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
+    public func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration, completion: ((Bool) -> Void)?) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { completion?(true) }
+
         self.beginUpdates()
         _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
         self.endUpdates()
+
+        CATransaction.commit()
     }
 }
 
@@ -93,11 +98,10 @@ extension UICollectionView : SectionedViewType {
         self.reloadSections(indexSet(sections))
     }
     
-  public func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
+    public func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration, completion: ((Bool) -> Void)?) {
         self.performBatchUpdates({ () -> Void in
             _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
-        }, completion: { (completed: Bool) -> Void in
-        })
+        }, completion: completion)
     }
 }
 
@@ -112,7 +116,7 @@ public protocol SectionedViewType {
     func moveSection(_ from: Int, to: Int)
     func reloadSections(_ sections: [Int], animationStyle: UITableViewRowAnimation)
 
-    func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration)
+    func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration, completion: ((Bool) -> Void)?)
 }
 
 func _performBatchUpdates<V: SectionedViewType, S>(_ view: V, changes: Changeset<S>, animationConfiguration:AnimationConfiguration) {


### PR DESCRIPTION
Currently there is no way observe when the animated updates have finished:

* UITableView is updated with `beginUpdates()` and `endUpdates()` and there is no completion block for that.
* UICollectionView is updated with `performBatchUpdates`, but the completion block is empty.

I had a case of animated data source that has a `isSelected: Bool` property and I need to scroll to a given item when the data source is updated. With current RxDataSources I would have to subclass UICollectionView and override `performBatchUpdates` method to do that. I think that simply handling the callback is a much simpler approach.

I had no idea how to detect `UITableView` updates, so I took the most popular answer from [Stack Overflow](https://stackoverflow.com/questions/7623771/how-to-detect-that-animation-has-ended-on-uitableview-beginupdates-endupdates?answertab=active#tab-top). I have added an example that demonstrates what I wanted to achieve and it seems to be working correctly.

It should also resolve #183. Let me know what you think.