### PR TITLE
Feature/perform batch updates in one go

### DIFF
--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -67,11 +67,17 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
                 }
                 let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
 
-                for difference in differences {
-                    dataSource.setSections(difference.finalSections)
-
-                    collectionView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
+                
+                if let finalSections = differences.last?.finalSections {
+                    dataSource.setSections(finalSections)
                 }
+                
+                collectionView.performBatchUpdates({
+                    for difference in differences {
+                        collectionView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
+                    }
+                    
+                }, completion: nil)
             }
             catch let e {
                 #if DEBUG

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -94,10 +94,7 @@ extension UICollectionView : SectionedViewType {
     }
     
   public func performBatchUpdates<S: SectionModelType>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
-        self.performBatchUpdates({ () -> Void in
-            _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
-        }, completion: { (completed: Bool) -> Void in
-        })
+        _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
     }
 }
 

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -93,7 +93,14 @@ extension UICollectionView : SectionedViewType {
         self.reloadSections(indexSet(sections))
     }
     
-  public func performBatchUpdates<S: SectionModelType>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
+    public func performBatchUpdates<S: SectionModelType>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
+        self.performBatchUpdates({ () -> Void in
+            _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
+        }, completion: { (completed: Bool) -> Void in
+        })
+    }
+    
+    public func performSingleBatchUpdates<S: SectionModelType>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
         _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
     }
 }


### PR DESCRIPTION
Needed to create the possibility of doing all the updates (deletes an inserts in one single batchUpdate)
As it was the when updating the last cell in the last section, would create an animation that looked wrong.
When the last cell in the last section is changed, it caused a delete and then insert, and since it didn't do simply and update to that cell, but actually do a delete, and then an insert, the collection view, would readjust to adapt to it's new size, and scroll the second to last item down.
This change actually creates an update. So the cell is just replaced with the new content, and no weird animation happens.