### PR TITLE
Provide a `custom` option for ViewTransition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## Master
+* Provide a `.custom` option for `ViewTransition`. #220
+
 ## [3.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.0.2)
 
 * Makes `configureSupplementaryView` optional for reload data source. #186

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -23,7 +23,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
     : CollectionViewSectionedDataSource<S>
     , RxCollectionViewDataSourceType {
     public typealias Element = [S]
-    public typealias DecideViewTransition = (CollectionViewSectionedDataSource<S>, UICollectionView, [Changeset<S>]) -> ViewTransition
+    public typealias DecideViewTransition = (CollectionViewSectionedDataSource<S>, UICollectionView, [Changeset<S>]) -> ViewTransition<UICollectionView>
 
     // animation configuration
     public var animationConfiguration: AnimationConfiguration
@@ -97,6 +97,9 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
                 case .reload:
                     self.setSections(newSections)
                     collectionView.reloadData()
+                case .custom(let actions):
+                    self.setSections(newSections)
+                    actions(collectionView)
                 }
             }
             catch let e {

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -19,7 +19,7 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
     : TableViewSectionedDataSource<S>
     , RxTableViewDataSourceType {
     public typealias Element = [S]
-    public typealias DecideViewTransition = (TableViewSectionedDataSource<S>, UITableView, [Changeset<S>]) -> ViewTransition
+    public typealias DecideViewTransition = (TableViewSectionedDataSource<S>, UITableView, [Changeset<S>]) -> ViewTransition<UITableView>
 
     /// Animation configuration for data source
     public var animationConfiguration: AnimationConfiguration
@@ -107,7 +107,9 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
                         case .reload:
                             self.setSections(newSections)
                             tableView.reloadData()
-                            return
+                        case .custom(let actions):
+                            self.setSections(newSections)
+                            actions(tableView)
                         }
                     }
                     catch let e {

--- a/Sources/RxDataSources/ViewTransition.swift
+++ b/Sources/RxDataSources/ViewTransition.swift
@@ -7,10 +7,11 @@
 //
 
 /// Transition between two view states
-public enum ViewTransition {
+public enum ViewTransition<T> {
     /// animated transition
     case animated
     /// refresh view without animations
     case reload
+    /// perform custom behavior
+    case custom((T) -> Void)
 }
-


### PR DESCRIPTION
## What ?
This PR aims to provide an additional flag to ViewTransitions besides `.reload` and `.animated`. 

## Why ?
In many scenarios - simple batch reloads might create a choppy animation or cause some UIKit-related animation glitches. 

Many of these are usually resolved by some sort of a “workaround” such as doing `beginUpdates`, `endUpdates` manually on a UITableView, or coordinate some other timing mechanism to overcome UIKit’s issue .

This PR lets users who wish to do so, an option to provide a custom transitioning logic for their entire UITableView / UICollectionView. 

## Breaking Changes

None. This is a purely additive change. 