### PR TITLE
Section model made equatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## Master
+* SectionModel made equatable when its model and items conforms to equatable.
+
 ## [3.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.0.2)
 
 * Makes `configureSupplementaryView` optional for reload data source. #186

--- a/Sources/Differentiator/SectionModel.swift
+++ b/Sources/Differentiator/SectionModel.swift
@@ -36,6 +36,15 @@ extension SectionModel
     }
 }
 
+extension SectionModel
+    : Equatable where Section: Equatable, ItemType: Equatable {
+    
+    public static func == (lhs: SectionModel, rhs: SectionModel) -> Bool {
+        return lhs.model == rhs.model
+            && lhs.items == rhs.items
+    }
+}
+
 extension SectionModel {
     public init(original: SectionModel<Section, Item>, items: [Item]) {
         self.model = original.model


### PR DESCRIPTION
It'll be very convenient to make SectionModel Equatable when its var's conforms to equatable.

For example, I use it in tests, when I need to check that SectionModel built right.

Or sometimes it may help when I'm using it as a part of the state for RxFeedback, to make the whole state distinctUntilChanged().