### PR TITLE
Reduce computational complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+#### Enhancements
+* Reduce computational complexity. #242
+
 ## [3.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.0.2)
 
 * Makes `configureSupplementaryView` optional for reload data source. #186

--- a/Sources/Differentiator/Changeset.swift
+++ b/Sources/Differentiator/Changeset.swift
@@ -78,15 +78,15 @@ extension Changeset
         let serializedSections = "[\n" + finalSections.map { "\($0)" }.joined(separator: ",\n") + "\n]\n"
         return " >> Final sections"
         + "   \n\(serializedSections)"
-        + (insertedSections.count > 0 || deletedSections.count > 0 || movedSections.count > 0 || updatedSections.count > 0 ? "\nSections:" : "")
-        + (insertedSections.count > 0 ? "\ninsertedSections:\n\t\(insertedSections)" : "")
-        + (deletedSections.count > 0 ?  "\ndeletedSections:\n\t\(deletedSections)" : "")
-        + (movedSections.count > 0 ? "\nmovedSections:\n\t\(movedSections)" : "")
-        + (updatedSections.count > 0 ? "\nupdatesSections:\n\t\(updatedSections)" : "")
-            + (insertedItems.count > 0 || deletedItems.count > 0 || movedItems.count > 0 || updatedItems.count > 0 ? "\nItems:" : "")
-        + (insertedItems.count > 0 ? "\ninsertedItems:\n\t\(insertedItems)" : "")
-        + (deletedItems.count > 0 ? "\ndeletedItems:\n\t\(deletedItems)" : "")
-        + (movedItems.count > 0 ? "\nmovedItems:\n\t\(movedItems)" : "")
-        + (updatedItems.count > 0 ? "\nupdatedItems:\n\t\(updatedItems)" : "")
+        + (!insertedSections.isEmpty || !deletedSections.isEmpty || !movedSections.isEmpty || !updatedSections.isEmpty ? "\nSections:" : "")
+        + (!insertedSections.isEmpty ? "\ninsertedSections:\n\t\(insertedSections)" : "")
+        + (!deletedSections.isEmpty ?  "\ndeletedSections:\n\t\(deletedSections)" : "")
+        + (!movedSections.isEmpty ? "\nmovedSections:\n\t\(movedSections)" : "")
+        + (!updatedSections.isEmpty ? "\nupdatesSections:\n\t\(updatedSections)" : "")
+            + (!insertedItems.isEmpty || !deletedItems.isEmpty || !movedItems.isEmpty || !updatedItems.isEmpty ? "\nItems:" : "")
+        + (!insertedItems.isEmpty ? "\ninsertedItems:\n\t\(insertedItems)" : "")
+        + (!deletedItems.isEmpty ? "\ndeletedItems:\n\t\(deletedItems)" : "")
+        + (!movedItems.isEmpty ? "\nmovedItems:\n\t\(movedItems)" : "")
+        + (!updatedItems.isEmpty ? "\nupdatedItems:\n\t\(updatedItems)" : "")
     }
 }

--- a/Sources/Differentiator/Diff.swift
+++ b/Sources/Differentiator/Diff.swift
@@ -648,7 +648,7 @@ public enum Diff {
             }
             // }
 
-            if deletedItems.count == 0 && deletedSections.count == 0 && updatedItems.count == 0 {
+            if deletedItems.isEmpty && deletedSections.isEmpty && updatedItems.isEmpty {
                 return []
             }
 
@@ -687,7 +687,7 @@ public enum Diff {
                 }
             }
             
-            if insertedSections.count ==  0 && movedSections.count == 0 {
+            if insertedSections.isEmpty && movedSections.isEmpty {
                 return []
             }
             
@@ -780,7 +780,7 @@ public enum Diff {
             }
             // }
             
-            if insertedItems.count == 0 && movedItems.count == 0 {
+            if insertedItems.isEmpty && movedItems.isEmpty {
                 return []
             }
             return [Changeset(

--- a/Tests/RxDataSourcesTests/ChangeSet+TestExtensions.swift
+++ b/Tests/RxDataSourcesTests/ChangeSet+TestExtensions.swift
@@ -125,7 +125,7 @@ extension Changeset {
     }
 
     private func applySectionMovesAndInserts(original: [S]) -> [S] {
-        if updatedSections.count > 0 {
+        if !updatedSections.isEmpty {
             fatalError("Section updates aren't supported")
         }
 

--- a/Tests/RxDataSourcesTests/Randomizer.swift
+++ b/Tests/RxDataSourcesTests/Randomizer.swift
@@ -152,7 +152,7 @@ struct Randomizer {
 
         // move items
         for _ in 0 ..< itemActionCount {
-            if sections.count == 0 {
+            if sections.isEmpty {
                 continue
             }
 
@@ -162,14 +162,12 @@ struct Randomizer {
             (nextRng, randomValue) = nextRng.get_random()
             let destinationSectionIndex = randomValue % sections.count
 
-            let sectionItemCount = sections[sourceSectionIndex].numbers.count
-
-            if sectionItemCount == 0 {
+            if sections[sourceSectionIndex].numbers.isEmpty {
                 continue
             }
 
             (nextRng, randomValue) = nextRng.get_random()
-            let sourceItemIndex = randomValue % sectionItemCount
+            let sourceItemIndex = randomValue % sections[sourceSectionIndex].numbers.count
 
             (nextRng, randomValue) = nextRng.get_random()
 
@@ -185,21 +183,19 @@ struct Randomizer {
 
         // delete items
         for _ in 0 ..< itemActionCount {
-            if sections.count == 0 {
+            if sections.isEmpty {
                 continue
             }
 
             (nextRng, randomValue) = nextRng.get_random()
             let sourceSectionIndex = randomValue % sections.count
 
-            let sectionItemCount = sections[sourceSectionIndex].numbers.count
-
-            if sectionItemCount == 0 {
+            if sections[sourceSectionIndex].numbers.isEmpty {
                 continue
             }
 
             (nextRng, randomValue) = nextRng.get_random()
-            let sourceItemIndex = randomValue % sectionItemCount
+            let sourceItemIndex = randomValue % sections[sourceSectionIndex].numbers.count
 
             if deleteItems {
                 nextUnusedItems.append(sections[sourceSectionIndex].numbers.remove(at: sourceItemIndex))
@@ -211,7 +207,7 @@ struct Randomizer {
 
         // move sections
         for _ in 0 ..< sectionActionCount {
-            if sections.count == 0 {
+            if sections.isEmpty {
                 continue
             }
 
@@ -231,7 +227,7 @@ struct Randomizer {
 
         // delete sections
         for _ in 0 ..< sectionActionCount {
-            if sections.count == 0 {
+            if sections.isEmpty {
                 continue
             }
 


### PR DESCRIPTION
Hi.

I reduced computational complexity.

The computational complexity of calculation `count` is O(N) unless the collection guarantees random-access performance.
To check whether a collection is empty, you should use `isEmpty` property.
See Apple Document [here](https://developer.apple.com/documentation/swift/array/2949997-count) for details.

The `isEmpty` property is O(1) operation.
