### PR TITLE
Resolve issue on reload with auto-layout cells

### DIFF
--- a/Sources/RxDataSources/RxCollectionViewSectionedReloadDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedReloadDataSource.swift
@@ -28,7 +28,11 @@ open class RxCollectionViewSectionedReloadDataSource<S: SectionModelType>
             #endif
             dataSource.setSections(element)
             collectionView.reloadData()
-            collectionView.collectionViewLayout.invalidateLayout()
+            collectionView.performBatchUpdates(nil, completion: {
+                (_) in
+                // This needs to run here to make auto-layout work in custom layout.
+                collectionView.collectionViewLayout.invalidateLayout()
+            })
         }.on(observedEvent)
     }
 }


### PR DESCRIPTION
Regarding [docs](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates) of `performBatchUpdates`: `Completion: A completion handler block to execute when all of the operations are finished.`
`invalidateLayout` should be executed there to recalculate sizes of auto-layout cells.
#trivial