### PR TITLE
RxCollectionViewSectionedAnimatedDataSource non-throttled reload updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 #### Enhancements
 * Reduce computational complexity. #242
 * Adapted for RxSwift 4.2
+* Allow unthrottled reload updates for `RxCollectionViewSectionedAnimatedDataSource`.
 
 ## [3.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.0.2)
 

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -24,7 +24,11 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
     , RxCollectionViewDataSourceType {
     public typealias Element = [S]
     public typealias DecideViewTransition = (CollectionViewSectionedDataSource<S>, UICollectionView, [Changeset<S>]) -> ViewTransition
-
+    private enum Update {
+        case reload(collectionView: UICollectionView, newSections: [S])
+        case animated(collectionView: UICollectionView, differences: [Changeset<S>])
+    }
+    
     // animation configuration
     public var animationConfiguration: AnimationConfiguration
 
@@ -47,69 +51,49 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
             moveItem: moveItem,
             canMoveItemAtIndexPath: canMoveItemAtIndexPath
         )
-
-        self.partialUpdateEvent
+        
+        let cancelableAnimatedUpdates = PublishRelay<(UICollectionView, [Changeset<S>])?>()
+        self.animatedUpdates.bind(to: cancelableAnimatedUpdates).disposed(by: disposeBag)
+        let throttledAnimatedUpdates = cancelableAnimatedUpdates
             // so in case it does produce a crash, it will be after the data has changed
             .observeOn(MainScheduler.asyncInstance)
             // Collection view has issues digesting fast updates, this should
             // help to alleviate the issues with them.
             .throttle(0.5, scheduler: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] event in
-                self?.collectionView(event.0, throttledObservedEvent: event.1)
-            })
-            .disposed(by: disposeBag)
+            .filter { $0 != nil }
+            .map { $0! }
+        Observable.merge([
+            self.reloadUpdates.map { Update.reload(collectionView: $0.0, newSections: $0.1) },
+            throttledAnimatedUpdates.map { Update.animated(collectionView: $0.0, differences: $0.1) }
+            ]).subscribe(onNext: { [weak self] update in
+                guard let `self` = self else { return }
+                switch update {
+                case .reload(let collectionView, let newSections):
+                    self.setSections(newSections)
+                    collectionView.reloadData()
+                    cancelableAnimatedUpdates.accept(nil) // Cancel any throttled animated updates as they are no longer valid
+                case .animated(let collectionView, let differences):
+                    for difference in differences {
+                        self.setSections(difference.finalSections)
+                        collectionView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
+                    }
+                }
+            }).disposed(by: self.disposeBag)
     }
-
+    
     // For some inexplicable reason, when doing animated updates first time
     // it crashes. Still need to figure out that one.
     var dataSet = false
-
+    
     private let disposeBag = DisposeBag()
-
-    // This subject and throttle are here
+    
+    private let reloadUpdates = PublishRelay<(UICollectionView, [S])>()
+    
+    // This relay and throttle are here
     // because collection view has problems processing animated updates fast.
     // This should somewhat help to alleviate the problem.
-    private let partialUpdateEvent = PublishSubject<(UICollectionView, Event<Element>)>()
-
-    /**
-     This method exists because collection view updates are throttled because of internal collection view bugs.
-     Collection view behaves poorly during fast updates, so this should remedy those issues.
-    */
-    open func collectionView(_ collectionView: UICollectionView, throttledObservedEvent event: Event<Element>) {
-        Binder(self) { dataSource, newSections in
-            let oldSections = dataSource.sectionModels
-            do {
-                // if view is not in view hierarchy, performing batch updates will crash the app
-                if collectionView.window == nil {
-                    dataSource.setSections(newSections)
-                    collectionView.reloadData()
-                    return
-                }
-                let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
-
-                switch self.decideViewTransition(self, collectionView, differences) {
-                case .animated:
-                    for difference in differences {
-                        dataSource.setSections(difference.finalSections)
-
-                        collectionView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
-                    }
-                case .reload:
-                    self.setSections(newSections)
-                    collectionView.reloadData()
-                }
-            }
-            catch let e {
-                #if DEBUG
-                    print("Error while binding data animated: \(e)\nFallback to normal `reloadData` behavior.")
-                    rxDebugFatalError(e)
-                #endif
-                self.setSections(newSections)
-                collectionView.reloadData()
-            }
-        }.on(event)
-    }
-
+    private let animatedUpdates = PublishRelay<(UICollectionView, [Changeset<S>])>()
+    
     open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, newSections in
             #if DEBUG
@@ -117,12 +101,31 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
             #endif
             if !self.dataSet {
                 self.dataSet = true
-                dataSource.setSections(newSections)
-                collectionView.reloadData()
+                self.reloadUpdates.accept((collectionView, newSections))
             }
             else {
-                let element = (collectionView, observedEvent)
-                dataSource.partialUpdateEvent.on(.next(element))
+                do {
+                    let oldSections = dataSource.sectionModels
+                    let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
+                    switch self.decideViewTransition(self, collectionView, differences) {
+                    case .animated:
+                        // if view is not in view hierarchy, performing batch updates will crash the app
+                        if collectionView.window == nil {
+                            self.reloadUpdates.accept((collectionView, newSections))
+                            return
+                        }
+                        dataSource.animatedUpdates.accept((collectionView, differences))
+                    case .reload:
+                        self.reloadUpdates.accept((collectionView, newSections))
+                    }
+                }
+                catch let e {
+                    #if DEBUG
+                    print("Error while binding data animated: \(e)\nFallback to normal `reloadData` behavior.")
+                    rxDebugFatalError(e)
+                    #endif
+                    self.reloadUpdates.accept((collectionView, newSections))
+                }
             }
         }.on(observedEvent)
     }

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -53,7 +53,9 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
         )
         
         let cancelableAnimatedUpdates = PublishRelay<(UICollectionView, [Changeset<S>])?>()
-        self.animatedUpdates.bind(to: cancelableAnimatedUpdates).disposed(by: disposeBag)
+        self.animatedUpdates.subscribe(onNext: { [weak cancelableAnimatedUpdates] in
+            cancelableAnimatedUpdates?.accept($0)
+        }).disposed(by: disposeBag)
         let throttledAnimatedUpdates = cancelableAnimatedUpdates
             // so in case it does produce a crash, it will be after the data has changed
             .observeOn(MainScheduler.asyncInstance)

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -99,26 +99,26 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
     open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, newSections in
             #if DEBUG
-                self._dataSourceBound = true
+                dataSource._dataSourceBound = true
             #endif
-            if !self.dataSet {
-                self.dataSet = true
-                self.reloadUpdates.accept((collectionView, newSections))
+            if !dataSource.dataSet {
+                dataSource.dataSet = true
+                dataSource.reloadUpdates.accept((collectionView, newSections))
             }
             else {
                 do {
                     let oldSections = dataSource.sectionModels
                     let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
-                    switch self.decideViewTransition(self, collectionView, differences) {
+                    switch dataSource.decideViewTransition(dataSource, collectionView, differences) {
                     case .animated:
                         // if view is not in view hierarchy, performing batch updates will crash the app
                         if collectionView.window == nil {
-                            self.reloadUpdates.accept((collectionView, newSections))
+                            dataSource.reloadUpdates.accept((collectionView, newSections))
                             return
                         }
                         dataSource.animatedUpdates.accept((collectionView, differences))
                     case .reload:
-                        self.reloadUpdates.accept((collectionView, newSections))
+                        dataSource.reloadUpdates.accept((collectionView, newSections))
                     }
                 }
                 catch let e {
@@ -126,7 +126,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
                     print("Error while binding data animated: \(e)\nFallback to normal `reloadData` behavior.")
                     rxDebugFatalError(e)
                     #endif
-                    self.reloadUpdates.accept((collectionView, newSections))
+                    dataSource.reloadUpdates.accept((collectionView, newSections))
                 }
             }
         }.on(observedEvent)


### PR DESCRIPTION
In an app that I work on we have a collection view that is using `RxCollectionViewSectionedAnimatedDataSource` to animate changes. This collection view uses a flow layout and allows the user to switch between two different layouts, a grid layout and a row layout. The collection view dequeues a different type of cell for each layout type, so when the user changes the layout type we push an updated version of the view model data into our data source, which triggers a reload of the cells.

The problem that we are having is that the animation of these changes looks very rough if several changes happen in relatively quick succession. The collection view layout changes happen immediately and therefore have the potential to be out of sync with the corresponding data source changes due to the throttling that happens internally in `RxCollectionViewSectionedAnimatedDataSource`. As I understand it this throttling is there to prevent issues with `UICollectionView` when processing updates in quick succession.  However, in our `decideViewTransition` closure we detect that a layout change is taking place and return `ViewTransition.reload` to prevent the data source from attempting to animate between the two states; in my opinion these updates should not be throttled. I propose to change `RxCollectionViewSectionedAnimatedDataSource` so that throttling occurs for animated updates but not for reload updates. If there is any constraint preventing us from making this change please let me know.

I have made an attempt at an implementation, but would appreciate suggestions for how to make it more straightforward and readable.

I have attached a clip of the issue appearing in a small sample application (I can provide the source code if necessary). In the sample, the grid cells are supposed to appear with a black border and the row cells are supposed to appear with no border. As you can see, changing quickly between the two states causes an unintended staggered transition.

![sample](https://user-images.githubusercontent.com/20034674/45269811-35a1ab00-b4e8-11e8-8304-869206777756.gif)