### PR TITLE
Makes SectionModel and AnimatableSectionModel equatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 #### Enhancements
 * Reduce computational complexity. #242
 * Adapted for RxSwift 4.2
-* SectionModel made equatable when its model and items conforms to equatable.
+* Makes SectionModel equatable when its model and items conforms to equatable.
 
 ## [3.1.0](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 #### Enhancements
 * Reduce computational complexity. #242
 * Adapted for RxSwift 4.2
-* Makes SectionModel equatable when its model and items conforms to equatable.
+* Makes SectionModel and AnimatableSectionModel equatable when their model and items conforms to equatable.
 
 ## [3.1.0](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 #### Enhancements
 * Reduce computational complexity. #242
 * Adapted for RxSwift 4.2
+* SectionModel made equatable when its model and items conforms to equatable.
 
 ## [3.1.0](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.1.0)
 

--- a/Sources/Differentiator/AnimatableSectionModel.swift
+++ b/Sources/Differentiator/AnimatableSectionModel.swift
@@ -47,3 +47,14 @@ extension AnimatableSectionModel
     }
 
 }
+
+#if swift(>=4.1)
+extension AnimatableSectionModel
+    : Equatable where Section: Equatable {
+    
+    public static func == (lhs: AnimatableSectionModel, rhs: AnimatableSectionModel) -> Bool {
+        return lhs.model == rhs.model
+            && lhs.items == rhs.items
+    }
+}
+#endif

--- a/Sources/Differentiator/SectionModel.swift
+++ b/Sources/Differentiator/SectionModel.swift
@@ -37,7 +37,12 @@ extension SectionModel
 }
 
 extension SectionModel
-    : Equatable where Section: Equatable, ItemType: Equatable {}
+    : Equatable where Section: Equatable, ItemType: Equatable {
+    public static func == (lhs: SectionModel, rhs: SectionModel) -> Bool {
+        return lhs.model == rhs.model
+            && lhs.items == rhs.items
+    }
+}
 
 extension SectionModel {
     public init(original: SectionModel<Section, Item>, items: [Item]) {

--- a/Sources/Differentiator/SectionModel.swift
+++ b/Sources/Differentiator/SectionModel.swift
@@ -36,6 +36,9 @@ extension SectionModel
     }
 }
 
+extension SectionModel
+    : Equatable where Section: Equatable, ItemType: Equatable {}
+
 extension SectionModel {
     public init(original: SectionModel<Section, Item>, items: [Item]) {
         self.model = original.model

--- a/Sources/Differentiator/SectionModel.swift
+++ b/Sources/Differentiator/SectionModel.swift
@@ -36,19 +36,20 @@ extension SectionModel
     }
 }
 
-#if swift(>=4.1)
-extension SectionModel
-    : Equatable where Section: Equatable, ItemType: Equatable {
-    public static func == (lhs: SectionModel, rhs: SectionModel) -> Bool {
-        return lhs.model == rhs.model
-            && lhs.items == rhs.items
-    }
-}
-#endif
-
 extension SectionModel {
     public init(original: SectionModel<Section, Item>, items: [Item]) {
         self.model = original.model
         self.items = items
     }
 }
+
+#if swift(>=4.1)
+extension SectionModel
+    : Equatable where Section: Equatable, ItemType: Equatable {
+    
+    public static func == (lhs: SectionModel, rhs: SectionModel) -> Bool {
+        return lhs.model == rhs.model
+            && lhs.items == rhs.items
+    }
+}
+#endif

--- a/Sources/Differentiator/SectionModel.swift
+++ b/Sources/Differentiator/SectionModel.swift
@@ -36,6 +36,7 @@ extension SectionModel
     }
 }
 
+#if swift(>=4.1)
 extension SectionModel
     : Equatable where Section: Equatable, ItemType: Equatable {
     public static func == (lhs: SectionModel, rhs: SectionModel) -> Bool {
@@ -43,6 +44,7 @@ extension SectionModel
             && lhs.items == rhs.items
     }
 }
+#endif
 
 extension SectionModel {
     public init(original: SectionModel<Section, Item>, items: [Item]) {


### PR DESCRIPTION
It'll be very convenient to make SectionModel Equatable when its var's conform to equatable.

For example, I use it in tests when I need to check that SectionModel built right.

Or sometimes it may help when I'm using it as a part of the state for RxFeedback, to make view state `distinctUntilChanged()`.