### PR TITLE
Make a unified UITableView performBatchUpdates func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-#### Enhancements
-* Reduce computational complexity. #242
-* Adapted for RxSwift 4.2
+## Unreleased
+
+* Make a unified `performBatchUpdates` func for `UITableView`.
 
 ## [3.1.0](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.1.0)
 
 * Xcode 10.0 compatibility.
+
+#### Enhancements
+* Reduce computational complexity. #242
+* Adapted for RxSwift 4.2
 
 ## [3.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.0.2)
 

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -58,9 +58,15 @@ extension UITableView : SectionedViewType {
     }
 
     public func performBatchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration) {
-        self.beginUpdates()
-        _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
-        self.endUpdates()
+        if #available(iOS 11, tvOS 11, *) {
+            performBatchUpdates({
+                _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
+            }, completion: nil)
+        } else {
+            beginUpdates()
+            _performBatchUpdates(self, changes: changes, animationConfiguration: animationConfiguration)
+            endUpdates()
+        }
     }
 }
 


### PR DESCRIPTION
A really small PR to make a unified `UITableView` **performBatchUpdates** func.
I think we could rely on this API when it is possible:
https://developer.apple.com/documentation/uikit/uitableview/2887515-performbatchupdates
