### PR TITLE
Crash resolved by setting sections within updateBlock of performBatchUpdates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Reduce computational complexity. #242
 * Adapted for RxSwift 4.2
 * Makes SectionModel and AnimatableSectionModel equatable when their model and items conforms to equatable.
+* Resolved issues with Animated Collection View #60
 
 ## [3.1.0](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/3.1.0)
 

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -15,10 +15,6 @@ import RxCocoa
 #endif
 import Differentiator
 
-/*
- This is commented becuse collection view has bugs when doing animated updates. 
- Take a look at randomized sections.
-*/
 open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
     : CollectionViewSectionedDataSource<S>
     , RxCollectionViewDataSourceType {
@@ -47,68 +43,11 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
             moveItem: moveItem,
             canMoveItemAtIndexPath: canMoveItemAtIndexPath
         )
-
-        self.partialUpdateEvent
-            // so in case it does produce a crash, it will be after the data has changed
-            .observeOn(MainScheduler.asyncInstance)
-            // Collection view has issues digesting fast updates, this should
-            // help to alleviate the issues with them.
-            .throttle(0.5, scheduler: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] event in
-                self?.collectionView(event.0, throttledObservedEvent: event.1)
-            })
-            .disposed(by: disposeBag)
     }
-
-    // For some inexplicable reason, when doing animated updates first time
-    // it crashes. Still need to figure out that one.
+    
+    // there is no longer limitation to load initial sections with reloadData
+    // but it is kept as a feature everyone got used to
     var dataSet = false
-
-    private let disposeBag = DisposeBag()
-
-    // This subject and throttle are here
-    // because collection view has problems processing animated updates fast.
-    // This should somewhat help to alleviate the problem.
-    private let partialUpdateEvent = PublishSubject<(UICollectionView, Event<Element>)>()
-
-    /**
-     This method exists because collection view updates are throttled because of internal collection view bugs.
-     Collection view behaves poorly during fast updates, so this should remedy those issues.
-    */
-    open func collectionView(_ collectionView: UICollectionView, throttledObservedEvent event: Event<Element>) {
-        Binder(self) { dataSource, newSections in
-            let oldSections = dataSource.sectionModels
-            do {
-                // if view is not in view hierarchy, performing batch updates will crash the app
-                if collectionView.window == nil {
-                    dataSource.setSections(newSections)
-                    collectionView.reloadData()
-                    return
-                }
-                let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
-
-                switch self.decideViewTransition(self, collectionView, differences) {
-                case .animated:
-                    for difference in differences {
-                        dataSource.setSections(difference.finalSections)
-
-                        collectionView.performBatchUpdates(difference, animationConfiguration: self.animationConfiguration)
-                    }
-                case .reload:
-                    self.setSections(newSections)
-                    collectionView.reloadData()
-                }
-            }
-            catch let e {
-                #if DEBUG
-                    print("Error while binding data animated: \(e)\nFallback to normal `reloadData` behavior.")
-                    rxDebugFatalError(e)
-                #endif
-                self.setSections(newSections)
-                collectionView.reloadData()
-            }
-        }.on(event)
-    }
 
     open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, newSections in
@@ -121,8 +60,41 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
                 collectionView.reloadData()
             }
             else {
-                let element = (collectionView, observedEvent)
-                dataSource.partialUpdateEvent.on(.next(element))
+                DispatchQueue.main.async {
+                    // if view is not in view hierarchy, performing batch updates will crash the app
+                    if collectionView.window == nil {
+                        dataSource.setSections(newSections)
+                        collectionView.reloadData()
+                        return
+                    }
+                    let oldSections = dataSource.sectionModels
+                    do {
+                        let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
+                        
+                        switch self.decideViewTransition(self, collectionView, differences) {
+                        case .animated:
+                            // each difference must be run in a separate performBatchUpdate, otherwise it crashes.
+                            // this is a limitation of Diff tool
+                            for difference in differences {
+                                collectionView.performBatchUpdates({ [unowned self] in
+                                    // sections must be set within updateBlock in performBatchUpdates
+                                    dataSource.setSections(difference.finalSections)
+                                    collectionView.batchUpdates(difference, animationConfiguration: self.animationConfiguration)
+                                    }, completion: nil)
+                            }
+                            
+                        case .reload:
+                            self.setSections(newSections)
+                            collectionView.reloadData()
+                            return
+                        }
+                    }
+                    catch let e {
+                        rxDebugFatalError(e)
+                        self.setSections(newSections)
+                        collectionView.reloadData()
+                    }
+                }
             }
         }.on(observedEvent)
     }

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -73,11 +73,11 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
                         
                         switch self.decideViewTransition(self, collectionView, differences) {
                         case .animated:
-                            // each difference must be run in a separate performBatchUpdate, otherwise it crashes.
+                            // each difference must be run in a separate 'performBatchUpdates', otherwise it crashes.
                             // this is a limitation of Diff tool
                             for difference in differences {
                                 collectionView.performBatchUpdates({ [unowned self] in
-                                    // sections must be set within updateBlock in performBatchUpdates
+                                    // sections must be set within updateBlock in 'performBatchUpdates'
                                     dataSource.setSections(difference.finalSections)
                                     collectionView.batchUpdates(difference, animationConfiguration: self.animationConfiguration)
                                     }, completion: nil)

--- a/Sources/RxDataSources/RxCollectionViewSectionedReloadDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedReloadDataSource.swift
@@ -24,7 +24,7 @@ open class RxCollectionViewSectionedReloadDataSource<S: SectionModelType>
     open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, element in
             #if DEBUG
-                self._dataSourceBound = true
+                dataSource._dataSourceBound = true
             #endif
             dataSource.setSections(element)
             collectionView.reloadData()

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -107,7 +107,7 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
                                     dataSource.setSections(difference.finalSections)
                                     tableView.batchUpdates(difference, animationConfiguration: self.animationConfiguration)
                                 }
-                                if #available(iOS 11, *) {
+                                if #available(iOS 11, tvOS 11, *) {
                                     tableView.performBatchUpdates(updateBlock, completion: nil)
                                 } else {
                                     tableView.beginUpdates()

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -99,11 +99,11 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
 
                         switch self.decideViewTransition(self, tableView, differences) {
                         case .animated:
-                            // each difference must be run in a separate performBatchUpdate, otherwise it crashes.
+                            // each difference must be run in a separate 'performBatchUpdates', otherwise it crashes.
                             // this is a limitation of Diff tool
                             for difference in differences {
                                 let updateBlock = { [unowned self] in
-                                    // sections must be set within updateBlock in performBatchUpdates
+                                    // sections must be set within updateBlock in 'performBatchUpdates'
                                     dataSource.setSections(difference.finalSections)
                                     tableView.batchUpdates(difference, animationConfiguration: self.animationConfiguration)
                                 }

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -78,55 +78,53 @@ open class RxTableViewSectionedAnimatedDataSource<S: AnimatableSectionModelType>
     open func tableView(_ tableView: UITableView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, newSections in
             #if DEBUG
-                self._dataSourceBound = true
+                dataSource._dataSourceBound = true
             #endif
-            if !self.dataSet {
-                self.dataSet = true
+            if !dataSource.dataSet {
+                dataSource.dataSet = true
                 dataSource.setSections(newSections)
                 tableView.reloadData()
             }
             else {
-                DispatchQueue.main.async {
-                    // if view is not in view hierarchy, performing batch updates will crash the app
-                    if tableView.window == nil {
+                // if view is not in view hierarchy, performing batch updates will crash the app
+                if tableView.window == nil {
+                    dataSource.setSections(newSections)
+                    tableView.reloadData()
+                    return
+                }
+                let oldSections = dataSource.sectionModels
+                do {
+                    let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
+                    
+                    switch dataSource.decideViewTransition(dataSource, tableView, differences) {
+                    case .animated:
+                        // each difference must be run in a separate 'performBatchUpdates', otherwise it crashes.
+                        // this is a limitation of Diff tool
+                        for difference in differences {
+                            let updateBlock = {
+                                // sections must be set within updateBlock in 'performBatchUpdates'
+                                dataSource.setSections(difference.finalSections)
+                                tableView.batchUpdates(difference, animationConfiguration: dataSource.animationConfiguration)
+                            }
+                            if #available(iOS 11, tvOS 11, *) {
+                                tableView.performBatchUpdates(updateBlock, completion: nil)
+                            } else {
+                                tableView.beginUpdates()
+                                updateBlock()
+                                tableView.endUpdates()
+                            }
+                        }
+                        
+                    case .reload:
                         dataSource.setSections(newSections)
                         tableView.reloadData()
                         return
                     }
-                    let oldSections = dataSource.sectionModels
-                    do {
-                        let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
-
-                        switch self.decideViewTransition(self, tableView, differences) {
-                        case .animated:
-                            // each difference must be run in a separate 'performBatchUpdates', otherwise it crashes.
-                            // this is a limitation of Diff tool
-                            for difference in differences {
-                                let updateBlock = { [unowned self] in
-                                    // sections must be set within updateBlock in 'performBatchUpdates'
-                                    dataSource.setSections(difference.finalSections)
-                                    tableView.batchUpdates(difference, animationConfiguration: self.animationConfiguration)
-                                }
-                                if #available(iOS 11, tvOS 11, *) {
-                                    tableView.performBatchUpdates(updateBlock, completion: nil)
-                                } else {
-                                    tableView.beginUpdates()
-                                    updateBlock()
-                                    tableView.endUpdates()
-                                }
-                            }
-                            
-                        case .reload:
-                            self.setSections(newSections)
-                            tableView.reloadData()
-                            return
-                        }
-                    }
-                    catch let e {
-                        rxDebugFatalError(e)
-                        self.setSections(newSections)
-                        tableView.reloadData()
-                    }
+                }
+                catch let e {
+                    rxDebugFatalError(e)
+                    dataSource.setSections(newSections)
+                    tableView.reloadData()
                 }
             }
         }.on(observedEvent)

--- a/Sources/RxDataSources/RxTableViewSectionedReloadDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedReloadDataSource.swift
@@ -23,7 +23,7 @@ open class RxTableViewSectionedReloadDataSource<S: SectionModelType>
     open func tableView(_ tableView: UITableView, observedEvent: Event<Element>) {
         Binder(self) { dataSource, element in
             #if DEBUG
-                self._dataSourceBound = true
+                dataSource._dataSourceBound = true
             #endif
             dataSource.setSections(element)
             tableView.reloadData()

--- a/Sources/RxDataSources/UI+SectionedViewType.swift
+++ b/Sources/RxDataSources/UI+SectionedViewType.swift
@@ -102,8 +102,6 @@ public protocol SectionedViewType {
     func deleteSections(_ sections: [Int], animationStyle: UITableViewRowAnimation)
     func moveSection(_ from: Int, to: Int)
     func reloadSections(_ sections: [Int], animationStyle: UITableViewRowAnimation)
-
-    func batchUpdates<S>(_ changes: Changeset<S>, animationConfiguration: AnimationConfiguration)
 }
 
 extension SectionedViewType {


### PR DESCRIPTION
Related to issue #60 

According to [Apple Documentation](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates?language=swift):

> If the collection view's layout is not up to date before you call this method, a reload may occur. To avoid problems, you should update your data model inside the updates block or ensure the layout is updated before you call performBatchUpdates(_:completion:).

So I moved `setSections(_:)` into updateBlock of `performBatchUpdates(_:completion:)` for `RxCollectionViewSectionedAnimatedDataSource` and `RxTableViewSectionedAnimatedDataSource`.
Also I renamed `performBatchUpdates(_:animationConfiguration:)` into `batchUpdates(_:animationConfiguration:)` since it does not perform animations any longer.
