### PR TITLE
Fix the crash in Example3_TableViewEditing.swift

### DIFF
--- a/Examples/Example/Example3_TableViewEditing.swift
+++ b/Examples/Example/Example3_TableViewEditing.swift
@@ -140,8 +140,8 @@ struct SectionedTableViewState {
 
 extension TableViewEditingCommand {
     static func addRandomItem() -> TableViewEditingCommand {
-        let randSection = Int(arc4random_uniform(UInt32(3)))
-        let number = Int(arc4random_uniform(UInt32(100)))
+        let randSection = Int.random(in: 0...2)
+        let number = Int.random(in: 0...10000)
         let item = IntItem(number: number, date: Date())
         return TableViewEditingCommand.AppendItem(item: item, section: randSection)
     }


### PR DESCRIPTION
In the demo Example3_TableViewEditing, the old range of random number is 0...100, so when I click the add button for more than 10 times, it is easy to generate a same number.
Here, I make the random number range larger.