### PR TITLE
Fix typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ dataSource.titleForHeaderInSection = { dataSource, index in
   return dataSource.sectionModels[index].header
 }
 
-dataSource.titleForFooterInSection = { dataSource, indexPath in
+dataSource.titleForFooterInSection = { dataSource, index in
   return dataSource.sectionModels[index].footer
 }
 


### PR DESCRIPTION
One of the arguments of `dataSource.titleForFooterInSection`, `indexPath` is not correct.
`index` is right and also used in closure.