### PR TITLE
Async diffing prototype

### DIFF
--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -134,6 +134,9 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
                 return Observable<DiffingOutput<Section>>
                     .create({ (observer: AnyObserver<DiffingOutput<Section>>) -> Disposable in
                         defer {
+                            #if DEBUG
+                            let start = CFAbsoluteTimeGetCurrent()
+                            #endif
                             let result: DiffingResult<Section> = {
                                 guard reducer.force == false else {
                                     return .force(finalSections: reducer.finalSections)
@@ -150,6 +153,10 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
                             }()
                             let view = reducer.view
                             let output = DiffingOutput(result: result, view: view)
+                            #if DEBUG
+                            let milliseconds = Int(round((CFAbsoluteTimeGetCurrent() - start) * 1000))
+                            print("diffing: \(milliseconds) milliseconds")
+                            #endif
                             observer.onNext(output)
                             observer.onCompleted()
                         }

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -15,17 +15,41 @@ import RxCocoa
 #endif
 import Differentiator
 
+private struct DiffingInput<S> where S: AnimatableSectionModelType {
+
+    let sections: [S]
+    let view: UICollectionView
+}
+
+private struct DiffingOutput<S> where S: AnimatableSectionModelType {
+
+    let result: DiffingResult<S>
+    let view: UICollectionView
+}
+
+private enum DiffingResult<S> where S: AnimatableSectionModelType {
+
+    case differences([Changeset<S>], finalSections: [S])
+    case error(Error, finalSections: [S])
+    case force(finalSections: [S])
+}
+
 open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectionModelType>
     : CollectionViewSectionedDataSource<Section>
     , RxCollectionViewDataSourceType {
     public typealias Element = [Section]
     public typealias DecideViewTransition = (CollectionViewSectionedDataSource<Section>, UICollectionView, [Changeset<Section>]) -> ViewTransition
-
-    // animation configuration
+    /// Animation configuration
     public var animationConfiguration: AnimationConfiguration
-
+    /// Calculates differences asynchronously
+    public let asyncDiffing: Bool
     /// Calculates view transition depending on type of changes
     public var decideViewTransition: DecideViewTransition
+    /// Batch updates should be performed inside UIView.performWithoutAnimation
+    public let disableBatchUpdatesAnimation: Bool
+
+    private let disposeBag = DisposeBag()
+    private let relayInput = BehaviorRelay<DiffingInput<Section>?>(value: nil)
 
     public init(
         animationConfiguration: AnimationConfiguration = AnimationConfiguration(),
@@ -33,69 +57,116 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
         configureCell: @escaping ConfigureCell,
         configureSupplementaryView: ConfigureSupplementaryView? = nil,
         moveItem: @escaping MoveItem = { _, _, _ in () },
-        canMoveItemAtIndexPath: @escaping CanMoveItemAtIndexPath = { _, _ in false }
+        canMoveItemAtIndexPath: @escaping CanMoveItemAtIndexPath = { _, _ in false },
+        asyncDiffing: Bool = true,
+        disableBatchUpdatesAnimation: Bool = false
         ) {
         self.animationConfiguration = animationConfiguration
+        self.asyncDiffing = asyncDiffing
         self.decideViewTransition = decideViewTransition
+        self.disableBatchUpdatesAnimation = disableBatchUpdatesAnimation
         super.init(
             configureCell: configureCell,
             configureSupplementaryView: configureSupplementaryView,
             moveItem: moveItem,
             canMoveItemAtIndexPath: canMoveItemAtIndexPath
         )
+        self.prepare()
     }
-    
-    // there is no longer limitation to load initial sections with reloadData
-    // but it is kept as a feature everyone got used to
-    var dataSet = false
 
-    open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
-        Binder(self) { dataSource, newSections in
-            #if DEBUG
-                dataSource._dataSourceBound = true
-            #endif
-            if !dataSource.dataSet {
-                dataSource.dataSet = true
-                dataSource.setSections(newSections)
-                collectionView.reloadData()
-            }
-            else {
-                // if view is not in view hierarchy, performing batch updates will crash the app
-                if collectionView.window == nil {
-                    dataSource.setSections(newSections)
-                    collectionView.reloadData()
+    private func prepare() {
+        self.relayInput
+            .asObservable()
+            .compactMap({ $0 })
+            .observeOn(MainScheduler.instance)
+            .flatMapLatest({ [weak dataSource = self] (input: DiffingInput<Section>) -> Observable<DiffingOutput<Section>> in
+                assert(Thread.isMainThread)
+                guard let dataSource = dataSource else {
+                    return .never()
+                }
+                let view = input.view
+                guard view.window != nil else {
+                    let finalSections = input.sections
+                    let result = DiffingResult.force(finalSections: finalSections)
+                    let output = DiffingOutput(result: result, view: view)
+                    return Observable
+                        .just(output, scheduler: MainScheduler.instance)
+                }
+                let initialSections = dataSource.sectionModels
+                let scheduler: ImmediateSchedulerType = {
+                    if dataSource.asyncDiffing {
+                        return ConcurrentDispatchQueueScheduler(qos: .userInteractive)
+                    } else {
+                        return MainScheduler.instance
+                    }
+                }()
+                return Observable
+                    .just((), scheduler: scheduler)
+                    .map({ [asyncDiffing = dataSource.asyncDiffing, finalSections = input.sections] _ -> DiffingResult<Section> in
+                        assert(Thread.isMainThread != asyncDiffing)
+                        do {
+                            let differences = try Diff.differencesForSectionedView(
+                                initialSections: initialSections,
+                                finalSections: finalSections
+                            )
+                            return .differences(differences, finalSections: finalSections)
+                        } catch let error {
+                            return .error(error, finalSections: finalSections)
+                        }
+                    })
+                    .map({ DiffingOutput(result: $0, view: view) })
+                    .observeOn(MainScheduler.instance)
+            })
+            .bind(onNext: { [weak dataSource = self] (output: DiffingOutput<Section>) in
+                guard let dataSource = dataSource else {
                     return
                 }
-                let oldSections = dataSource.sectionModels
-                do {
-                    let differences = try Diff.differencesForSectionedView(initialSections: oldSections, finalSections: newSections)
-                    
-                    switch dataSource.decideViewTransition(dataSource, collectionView, differences) {
+                assert(Thread.isMainThread)
+                switch output.result {
+                case .differences(let differences, finalSections: let finalSections):
+                    switch dataSource.decideViewTransition(dataSource, output.view, differences) {
                     case .animated:
                         // each difference must be run in a separate 'performBatchUpdates', otherwise it crashes.
                         // this is a limitation of Diff tool
-                        for difference in differences {
-                            let updateBlock = {
-                                // sections must be set within updateBlock in 'performBatchUpdates'
-                                dataSource.setSections(difference.finalSections)
-                                collectionView.batchUpdates(difference, animationConfiguration: dataSource.animationConfiguration)
+                        let updates: () -> Void = {
+                            for difference in differences {
+                                let updateBlock = {
+                                    // sections must be set within updateBlock in 'performBatchUpdates'
+                                    dataSource.setSections(difference.finalSections)
+                                    output.view.batchUpdates(difference, animationConfiguration: dataSource.animationConfiguration)
+                                }
+                                output.view.performBatchUpdates(updateBlock, completion: nil)
                             }
-                            collectionView.performBatchUpdates(updateBlock, completion: nil)
                         }
-                        
+                        if dataSource.disableBatchUpdatesAnimation {
+                            UIView.performWithoutAnimation(updates)
+                        } else {
+                            updates()
+                        }
                     case .reload:
-                        dataSource.setSections(newSections)
-                        collectionView.reloadData()
-                        return
+                        dataSource.setSections(finalSections)
+                        output.view.reloadData()
                     }
+                case .error(let error, finalSections: let finalSections):
+                    rxDebugFatalError(error)
+                    dataSource.setSections(finalSections)
+                    output.view.reloadData()
+                case .force(finalSections: let finalSections):
+                    dataSource.setSections(finalSections)
+                    output.view.reloadData()
                 }
-                catch let e {
-                    rxDebugFatalError(e)
-                    dataSource.setSections(newSections)
-                    collectionView.reloadData()
-                }
-            }
-        }.on(observedEvent)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    open func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Element>) {
+        Binder(self, scheduler: MainScheduler.instance, binding: { [view = collectionView] (dataSource, sections: [Section]) in
+            let input = DiffingInput(sections: sections, view: view)
+            Observable
+                .just(input, scheduler: MainScheduler.instance)
+                .bind(to: dataSource.relayInput)
+                .disposed(by: dataSource.disposeBag)
+        }).on(observedEvent)
     }
 }
 #endif

--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -58,7 +58,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
         configureSupplementaryView: ConfigureSupplementaryView? = nil,
         moveItem: @escaping MoveItem = { _, _, _ in () },
         canMoveItemAtIndexPath: @escaping CanMoveItemAtIndexPath = { _, _ in false },
-        asyncDiffing: Bool = true,
+        asyncDiffing: Bool = false,
         disableBatchUpdatesAnimation: Bool = false
         ) {
         self.animationConfiguration = animationConfiguration


### PR DESCRIPTION
**The situation:**

I have "paging" mechanism for a user who scrolls down the catalog of goods. When new data is received I append it. I expect a user to never see the bottom of the catalog and all inserts should be as smooth as possible. To make it worse I have a complex layout with an invalidation on bounds change, _levitating_ headers footers etc... (_levitating_ != _sticky_, _sticky_ has predictable position, _levitating_ has unpredictable position which depends on user scroll directions). Since I have layout invalidation and some _levitating_ views - `reloadData()` is not a solution because the state of all the _levitating_ views will be dropped.

**The problem:**

Everything works fine for me, but I've found that `try Diff.differencesForSectionedView(initialSections: ...` might be a slow one. I'm 100% sure that the layout is efficient enough to provide a 60fps. In my case it takes up to ~0.2sec to calculate the differences when the data set is very big (on iPhone 6S). On modern devices the lag is also noticeable. So, it's important for me to remove the ~0.2sec lag.

**The solution:**

Since `RxCollectionViewSectionedAnimatedDataSource` is the only source of data for a view, I believe it won't be a big deal to move the Diff calculation to a non main thread. And when we know the Diff we go back to the main thread and apply them.

**The implementation:**

I've added two params to init method with default values:
```
asyncDiffing: Bool, disableBatchUpdatesAnimation: Bool
```
Nobody will get the async implementation if `asyncDiffing` default value is `false`. So it won't be a breaking change. The code is quite "dirty", I don't expect it to be merged right away. I just wanted to attract your attention to the problem and a possible solution.