### PR TITLE
Make Chanset.init() public so that it can be accessible in test targets

### DIFF
--- a/Sources/Differentiator/Changeset.swift
+++ b/Sources/Differentiator/Changeset.swift
@@ -26,17 +26,17 @@ public struct Changeset<Section: SectionModelType> {
     public let movedItems: [(from: ItemPath, to: ItemPath)]
     public let updatedItems: [ItemPath]
 
-    init(reloadData: Bool = false,
-         originalSections: [Section] = [],
-         finalSections: [Section] = [],
-         insertedSections: [Int] = [],
-         deletedSections: [Int] = [],
-         movedSections: [(from: Int, to: Int)] = [],
-         updatedSections: [Int] = [],
-         insertedItems: [ItemPath] = [],
-         deletedItems: [ItemPath] = [],
-         movedItems: [(from: ItemPath, to: ItemPath)] = [],
-         updatedItems: [ItemPath] = []) {
+    public init(reloadData: Bool = false,
+                originalSections: [Section] = [],
+                finalSections: [Section] = [],
+                insertedSections: [Int] = [],
+                deletedSections: [Int] = [],
+                movedSections: [(from: Int, to: Int)] = [],
+                updatedSections: [Int] = [],
+                insertedItems: [ItemPath] = [],
+                deletedItems: [ItemPath] = [],
+                movedItems: [(from: ItemPath, to: ItemPath)] = [],
+                updatedItems: [ItemPath] = []) {
         self.reloadData = reloadData
 
         self.originalSections = originalSections


### PR DESCRIPTION
This patch makes it available to mock `Changeset` so that it becomes easy to test the behavior of custom `decideNodeTransition`.

#trivial