### PR TITLE
Update to RxSwift 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 
 #### Master
 
+## [4.0.2](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/4.0.2)
+
 * Adds support of mutable CellViewModels.
 * Changes `TableViewSectionedDataSource` default parameters `canEditRowAtIndexPath` and `canMoveRowAtIndexPath` to align with iOS default behavior #383
+* Updated RxSwift to 5.1.1
 
 ## [4.0.1](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/4.0.1)
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 5.0
+github "ReactiveX/RxSwift" ~> 5.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "5.1.1"

--- a/Differentiator.podspec
+++ b/Differentiator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Differentiator"
-  s.version          = "4.0.1"
+  s.version          = "4.0.2"
   s.summary          = "Diff algorithm for UITableView and UICollectionView."
   s.description      = <<-DESC
   Diff algorithm for UITableView and UICollectionView.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "Differentiator", targets: ["Differentiator"])
   ],
   dependencies: [
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0"))
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1"))
   ],
   targets: [
     .target(name: "RxDataSources", dependencies: ["Differentiator", "RxSwift", "RxCocoa"]),

--- a/RxDataSources.podspec
+++ b/RxDataSources.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxDataSources"
-  s.version          = "4.0.1"
+  s.version          = "4.0.2"
   s.summary          = "This is a collection of reactive data sources for UITableView and UICollectionView."
   s.description      = <<-DESC
 This is a collection of reactive data sources for UITableView and UICollectionView.
@@ -38,8 +38,8 @@ data
 
   s.source_files = 'Sources/RxDataSources/**/*.swift'
   s.dependency 'Differentiator', '~> 4.0'
-  s.dependency 'RxSwift', '~> 5.0'
-  s.dependency 'RxCocoa', '~> 5.0'
+  s.dependency 'RxSwift', '~> 5.1'
+  s.dependency 'RxCocoa', '~> 5.1'
 
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
RxSwift 5.1.0 is out and we need to switch to that version.
The main reason is this: https://developer.apple.com/news/?id=12232019b
RxSwift 5.0.x or earlier has a dependency on UIWebView via RxCocoa. 
RxSwift 5.1.0 removes UIWebView dependency.