### PR TITLE
Adding support of mutable CellViewModels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: xcode10.2
+osx_image: xcode11.5
 
 notifications:
   slack: rxswift:3ykt2Z61f8GkdvhCZTYPduOL
@@ -10,9 +10,9 @@ install: true
 
 env:
   - BUILD="brew install swiftlint"
-  - BUILD="carthage update --platform iOS && pushd Examples && set -o pipefail && (xcodebuild -project Example.xcodeproj -scheme ExampleUITests -configuration Release -destination 'platform=iOS Simulator,name=iPhone 7' test && xcodebuild -project   Example.xcodeproj   -scheme Example -configuration Release -destination 'platform=iOS Simulator,name=iPhone 7' build) | xcpretty"
-  - BUILD="carthage update --platform ios && set -o pipefail && (xcodebuild -project   RxDataSources.xcodeproj   -scheme Tests -configuration Release -destination 'platform=iOS Simulator,name=iPhone 7' test) | xcpretty"
-  - BUILD="gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet; pod repo update && pod lib lint RxDataSources.podspec --verbose && pod lib lint Differentiator.podspec --verbose "
+  - BUILD="carthage update --platform iOS && pushd Examples && set -o pipefail && (xcodebuild -project Example.xcodeproj -scheme ExampleUITests -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8' test && xcodebuild -project   Example.xcodeproj   -scheme Example -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8' build) | xcpretty"
+  - BUILD="carthage update --platform iOS && set -o pipefail && (xcodebuild -project   RxDataSources.xcodeproj   -scheme Tests -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8' test) | xcpretty"
+  - BUILD="gem install cocoapods --pre --no-document --quiet; pod repo update && pod lib lint RxDataSources.podspec --verbose && pod lib lint Differentiator.podspec --verbose "
   - BUILD="carthage update --platform iOS  && carthage build --no-skip-current --platform iOS"
   - BUILD="carthage update --platform tvOS && carthage build --no-skip-current --platform tvOS"
   - BUILD="swift test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 #### Master
 
+* Added support of mutable CellViewModels.
+
 ## [4.0.1](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/4.0.1)
 
 * Fixes Carthage integration and reverts static frameworks to dynamic frameworks.

--- a/Sources/Differentiator/Diff.swift
+++ b/Sources/Differentiator/Diff.swift
@@ -623,8 +623,10 @@ public enum Diff {
                         let finalItem = finalItemCache[finalItemIndex.sectionIndex][finalItemIndex.itemIndex]
                         if finalItem != initialSections[i].items[j] {
                             updatedItems.append(ItemPath(sectionIndex: i, itemIndex: j))
+                            afterDeleteItems.append(finalItem)
+                        } else {
+                            afterDeleteItems.append(initialSections[i].items[j])
                         }
-                        afterDeleteItems.append(finalItem)
                     default:
                         try precondition(false, "Unhandled case")
                     }


### PR DESCRIPTION
Imagine that there is a cell/item that has a mutable state, that might be changed without reloading its model.
Here is a story:
There is a struct with a few properties and we would like to represent it via UITableView. The Struct could be mutated somehow. So we will wrap it into an Observable, and then map its properties on CellViewModel and then bind it to TableView. Seems pretty common and easy.
And then we decide that we would like to edit the Struct, so we add UITextFields to cells. Also we push updates from UITextField.text property to the Struct. Every update emits new CellViewModels array and RxDataSources make diff in order to perform updates in the TableView. It compares models and figures out that it is not equal (initial has old value and final has a new one we entered in a UITextField), so this forces the cell to reload and it stops to be a first responder. This is a situation we want to avoid. So we do next: when text is updated in a UITextField, we update the CellViewModel, so on next diff initial model will be equal to final one, what means no updates in TableView. Good, seems to be fixed.
But, then while we are updating the text, some other changes updates another property in the struct. This emits new CellViewModels array, while cell we are editing is not reloaded, there are still some reloads in a TableView. Then we update text once again, and our cell is reloaded. Wow, how could this happen?
As you may know, when diffs are generated, the algorithm performs all comparisons and returns finalSections. Items in this finalSections are used from newly emitted CellViewModels array. So it means that if there is an update in the TableView performed, a new CellViewModel will be stored for every cell even if they are equal. So after such update there will be two CellViewModels for the same cell. One is stored in sections inside TableView datasource and another is the one that is mutated by updating UITextField. And on a next diff, the model stored in section will be compared to a new one, and they will be not equal, what means a reload on cell we are editing.
In order to avoid that I propose to keep initial item instead of final item in case if they are equal.

