### PR TITLE
Set actual dataSource after diff applying

### DIFF
--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -82,6 +82,8 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
                             }
                             collectionView.performBatchUpdates(updateBlock, completion: nil)
                         }
+                        // Finaly, set actual datasource:
+                        dataSource.setSections(newSections)
                         
                     case .reload:
                         dataSource.setSections(newSections)

--- a/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxTableViewSectionedAnimatedDataSource.swift
@@ -114,6 +114,8 @@ open class RxTableViewSectionedAnimatedDataSource<Section: AnimatableSectionMode
                                 tableView.endUpdates()
                             }
                         }
+                        // Finaly, set actual datasource:
+                        dataSource.setSections(newSections)
                         
                     case .reload:
                         dataSource.setSections(newSections)


### PR DESCRIPTION
This is the second variant of https://github.com/RxSwiftCommunity/RxDataSources/pull/379
All tests succeeded, but I am still not fully sure it is correct. Seems Mikhail Markin and me having different aims.

The task I am trying to solve:
I have a cell with a cart button. When the cart button is tapped, a stepper with +- buttons appears. When I tap these buttons, I need to update the model. But model updating leads to cell reload, and stepper disappears. This is a problem.
The decision is to remove the model amount property from == and hash(into hasher:) functions. Thus the model is updated, but diff algorithm can't detect this fact, and finally, the row is not reloaded.

The same problem we have in a cell with UISwitch: when UISwitch changes value, the model is updated, which leads to cell reload, and UISwitch animation is interrupted. This effect is looking very ugly sometimes.
