### PR TITLE
Align default closures with default behavior of the delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 #### Master
 
-* Added support of mutable CellViewModels.
+* Adds support of mutable CellViewModels.
+* Changes `TableViewSectionedDataSource` default parameters `canEditRowAtIndexPath` and `canMoveRowAtIndexPath` to align with iOS default behavior #383
 
 ## [4.0.1](https://github.com/RxSwiftCommunity/RxDataSources/releases/tag/4.0.1)
 

--- a/Sources/RxDataSources/TableViewSectionedDataSource.swift
+++ b/Sources/RxDataSources/TableViewSectionedDataSource.swift
@@ -37,8 +37,8 @@ open class TableViewSectionedDataSource<Section: SectionModelType>
                 configureCell: @escaping ConfigureCell,
                 titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
                 titleForFooterInSection: @escaping TitleForFooterInSection = { _, _ in nil },
-                canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in false },
-                canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in false },
+                canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in true },
+                canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in true },
                 sectionIndexTitles: @escaping SectionIndexTitles = { _ in nil },
                 sectionForSectionIndexTitle: @escaping SectionForSectionIndexTitle = { _, _, index in index }
             ) {
@@ -55,8 +55,8 @@ open class TableViewSectionedDataSource<Section: SectionModelType>
                 configureCell: @escaping ConfigureCell,
                 titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
                 titleForFooterInSection: @escaping TitleForFooterInSection = { _, _ in nil },
-                canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in false },
-                canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in false }
+                canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in true },
+                canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in true }
             ) {
             self.configureCell = configureCell
             self.titleForHeaderInSection = titleForHeaderInSection


### PR DESCRIPTION
Fixes https://github.com/RxSwiftCommunity/RxDataSources/issues/382