### PR TITLE
chore: properly add submodule for RxSwift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Carthage/Checkouts/RxSwift"]
-	path = Carthage/Checkouts/RxSwift
 	url = https://github.com/ReactiveX/RxSwift.git
+	path = Carthage/Checkouts/RxSwift

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "ReactiveX/RxSwift" "6.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "c8742ed97fc2f0c015a5ea5eddefb064cd7532d2",
+          "version": "6.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
The .gitmodules file was present, but the submodule wasn't actually added. This messes with Carthage builds a bit (https://github.com/Carthage/Carthage/issues/1146 is one instance of it), but also probably want to have this synced up anyway if this is to use submodules to grab the dependency.