### PR TITLE
#trivial Omit completion from performBatchUpdates 

### DIFF
--- a/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/Sources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -80,7 +80,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<Section: AnimatableSectio
                                 dataSource.setSections(difference.finalSections)
                                 collectionView.batchUpdates(difference, animationConfiguration: dataSource.animationConfiguration)
                             }
-                            collectionView.performBatchUpdates(updateBlock, completion: nil)
+                            collectionView.performBatchUpdates(updateBlock)
                         }
                         
                     case .reload:


### PR DESCRIPTION
It would be simpler to omit the completion parameter from [performBatchUpdates(_:completion:)](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates) function instead of   setting `nil` because  the default value of the completion parameter is the same one.
