### PR TITLE
Fix items method in READMD.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ RxSwift helps alleviate some of the burden with a simple data binding mechanism:
 2) Bind the data to the tableView/collectionView using one of:
   - `rx.items(dataSource:protocol<RxTableViewDataSourceType, UITableViewDataSource>)`
   - `rx.items(cellIdentifier:String)`
-  - `rx.items(cellIdentifier:String:Cell.Type:_:)`
-  - `rx.items(_:_:)`
+  - `rx.items(cellIdentifier:String, cellType: Cell.Type)`
+  - `rx.items(_ source: ObservableType)`
 
 ```swift
 let data = Observable<[String]>.just(["first element", "second element", "third element"])


### PR DESCRIPTION
<img width="714" alt="스크린샷 2022-04-29 오후 5 29 06" src="https://user-images.githubusercontent.com/83381672/165916172-1dc449bb-2114-41a6-9441-e342e0f9a89a.png">

`rx.items(cellIdentifier:String:Cell.Type:_:)`
I don't know why ":" comes after "String"
Therefore, I would like to request this modification!

Thank you