### PR TITLE
Remove Carthage directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/RxSwift"]
-	url = https://github.com/ReactiveX/RxSwift.git
-	path = Carthage/Checkouts/RxSwift


### PR DESCRIPTION
I have noticed that when using SwiftPM, Xcode will resolve and download RxSwift twice. This is because it is listed both as a dependency in the Package.swift and also as a git submodule in .gitmodules.

For Carthage to resolve correctly I don't believe the submodule needs to be checked in, but I can try to find another solution if it is required.