### PR TITLE
Patch warnings for conformances of external types

### DIFF
--- a/Sources/RxDataSources/FloatingPointType+IdentifiableType.swift
+++ b/Sources/RxDataSources/FloatingPointType+IdentifiableType.swift
@@ -16,10 +16,10 @@ extension FloatingPoint {
     }
 }
 
-extension Float : IdentifiableType {
+extension Swift.Float : Differentiator.IdentifiableType {
 
 }
 
-extension Double : IdentifiableType {
+extension Swift.Double : Differentiator.IdentifiableType {
 
 }

--- a/Sources/RxDataSources/IntegerType+IdentifiableType.swift
+++ b/Sources/RxDataSources/IntegerType+IdentifiableType.swift
@@ -16,44 +16,44 @@ extension BinaryInteger {
     }
 }
 
-extension Int : IdentifiableType {
+extension Swift.Int : Differentiator.IdentifiableType {
 
 }
 
-extension Int8 : IdentifiableType {
+extension Swift.Int8 : Differentiator.IdentifiableType {
 
 }
 
-extension Int16 : IdentifiableType {
+extension Swift.Int16 : Differentiator.IdentifiableType {
 
 }
 
-extension Int32 : IdentifiableType {
+extension Swift.Int32 : Differentiator.IdentifiableType {
 
 }
 
-extension Int64 : IdentifiableType {
+extension Swift.Int64 : Differentiator.IdentifiableType {
 
 }
 
 
-extension UInt : IdentifiableType {
+extension Swift.UInt : Differentiator.IdentifiableType {
 
 }
 
-extension UInt8 : IdentifiableType {
+extension Swift.UInt8 : Differentiator.IdentifiableType {
 
 }
 
-extension UInt16 : IdentifiableType {
+extension Swift.UInt16 : Differentiator.IdentifiableType {
 
 }
 
-extension UInt32 : IdentifiableType {
+extension Swift.UInt32 : Differentiator.IdentifiableType {
 
 }
 
-extension UInt64 : IdentifiableType {
-    
+extension Swift.UInt64 : Differentiator.IdentifiableType {
+
 }
 

--- a/Sources/RxDataSources/String+IdentifiableType.swift
+++ b/Sources/RxDataSources/String+IdentifiableType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension String : IdentifiableType {
+extension Swift.String : Differentiator.IdentifiableType {
     public typealias Identity = String
 
     public var identity: String {


### PR DESCRIPTION
Add the source compatible patch for https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md to avoid warnings on Swift 6+ and still be able to compile on previous versions.

#trivial